### PR TITLE
Replace tokio, manage waking subscribers ourselves

### DIFF
--- a/eyeball/Cargo.toml
+++ b/eyeball/Cargo.toml
@@ -12,8 +12,6 @@ all-features = true
 [dependencies]
 futures-core.workspace = true
 readlock.workspace = true
-tokio.workspace = true
-tokio-stream.workspace = true
 tracing = { workspace = true, optional = true }
 
 # for benchmarking

--- a/eyeball/src/lib.rs
+++ b/eyeball/src/lib.rs
@@ -71,12 +71,14 @@
 
 mod observable;
 pub mod shared;
-mod subscriber;
+mod state;
+pub mod subscriber;
 
 use std::sync::{Arc, RwLock};
 
 pub use observable::Observable;
 use shared::SharedObservableBase;
+#[doc(inline)]
 pub use subscriber::{Subscriber, SubscriberReadGuard};
 
 /// A common type of shared observable, where shared ownership is achieved via

--- a/eyeball/src/state.rs
+++ b/eyeball/src/state.rs
@@ -1,0 +1,126 @@
+use std::{
+    hash::{Hash, Hasher},
+    mem,
+    sync::RwLock,
+    task::Waker,
+};
+
+#[derive(Debug)]
+pub(crate) struct ObservableState<T> {
+    /// The inner value.
+    value: T,
+
+    /// The version of the value.
+    ///
+    /// Starts at 1 and is incremented by 1 each time the value is updated.
+    /// When the observable is dropped, this is set to 0 to indicate no further
+    /// updates will happen.
+    version: u64,
+
+    /// List of wakers.
+    ///
+    /// This is part of `ObservableState` and uses extra locking so that it is
+    /// guaranteed that it's only updated by subscribers while the value is
+    /// locked for reading. This way, it is guaranteed that between a subscriber
+    /// reading the value and adding a waker because the value hasn't changed
+    /// yet, no updates to the value could have happened.
+    wakers: RwLock<Vec<Waker>>,
+}
+
+impl<T> ObservableState<T> {
+    pub(crate) fn new(value: T) -> Self {
+        Self { value, version: 1, wakers: Default::default() }
+    }
+
+    /// Get a reference to the inner value.
+    pub(crate) fn get(&self) -> &T {
+        &self.value
+    }
+
+    /// Get the current version of the inner value.
+    pub(crate) fn version(&self) -> u64 {
+        self.version
+    }
+
+    pub(crate) fn add_waker(&self, waker: Waker) {
+        self.wakers.write().unwrap().push(waker);
+    }
+
+    pub(crate) fn set(&mut self, value: T) {
+        self.value = value;
+        self.incr_version_and_wake();
+    }
+
+    pub(crate) fn replace(&mut self, value: T) -> T {
+        let result = mem::replace(&mut self.value, value);
+        self.incr_version_and_wake();
+        result
+    }
+
+    pub fn update(&mut self, f: impl FnOnce(&mut T)) {
+        f(&mut self.value);
+        self.incr_version_and_wake();
+    }
+
+    pub fn update_eq(&mut self, f: impl FnOnce(&mut T))
+    where
+        T: Clone + PartialEq,
+    {
+        let prev = self.value.clone();
+        f(&mut self.value);
+        if self.value != prev {
+            self.incr_version_and_wake();
+        }
+    }
+
+    pub fn update_hash(&mut self, f: impl FnOnce(&mut T))
+    where
+        T: Hash,
+    {
+        use std::collections::hash_map::DefaultHasher;
+
+        let mut hasher = DefaultHasher::new();
+        self.value.hash(&mut hasher);
+        let prev_hash = hasher.finish();
+
+        f(&mut self.value);
+
+        let mut hasher = DefaultHasher::new();
+        self.value.hash(&mut hasher);
+        let new_hash = hasher.finish();
+
+        if prev_hash != new_hash {
+            self.incr_version_and_wake();
+        }
+    }
+
+    /// "Close" the state – indicate that no further updates will happen.
+    pub(crate) fn close(&mut self) {
+        self.version = 0;
+        // Clear the backing buffer for the wakers, no new ones will be added.
+        wake(mem::take(self.wakers.get_mut().unwrap()));
+    }
+
+    fn incr_version_and_wake(&mut self) {
+        self.version += 1;
+        wake(self.wakers.get_mut().unwrap().drain(..));
+    }
+}
+
+fn wake<I>(wakers: I)
+where
+    I: IntoIterator<Item = Waker>,
+    I::IntoIter: ExactSizeIterator,
+{
+    let iter = wakers.into_iter();
+    #[cfg(feature = "tracing")]
+    {
+        let num_wakers = iter.len();
+        if num_wakers > 0 {
+            tracing::debug!("Waking up {num_wakers} waiting subscribers");
+        }
+    }
+    for waker in iter {
+        waker.wake();
+    }
+}


### PR DESCRIPTION
Unfortunately this is slower with high numbers of subscribers..

```
     Running benches/set_a_lot.rs (target/release/deps/set_a_lot-2dbaf3e0f2a29d73)
baseline                time:   [5.8696 µs 5.8888 µs 5.9085 µs]
                        change: [-3.7699% -2.1971% -0.7397%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

no_subscribers          time:   [8.9820 µs 8.9964 µs 9.0106 µs]
                        change: [-19.656% -19.441% -19.200%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  4 (4.00%) high severe

one_subscriber          time:   [21.037 µs 21.926 µs 22.849 µs]
                        change: [-64.838% -61.860% -58.690%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

two_subscribers         time:   [57.005 µs 59.346 µs 61.799 µs]
                        change: [-41.311% -38.612% -35.650%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

four_subscribers        time:   [79.389 µs 84.400 µs 89.619 µs]
                        change: [-37.565% -34.897% -32.136%] (p = 0.00 < 0.05)
                        Performance has improved.

sixteen_subscribers     time:   [540.11 µs 554.26 µs 567.44 µs]
                        change: [+98.290% +104.58% +110.95%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low severe
  2 (2.00%) high mild

sixtyfour_subscribers   time:   [3.0259 ms 3.1893 ms 3.3465 ms]
                        change: [+827.78% +878.43% +929.51%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) low mild
```