### PR TITLE
feat(util-im): Add a `DynamicLimit` adapter

### DIFF
--- a/eyeball-im-util/Cargo.toml
+++ b/eyeball-im-util/Cargo.toml
@@ -19,6 +19,7 @@ pin-project-lite = "0.2.9"
 
 [dev-dependencies]
 stream_assert.workspace = true
+eyeball = { version = "0.8.6", path = "../eyeball" }
 
 [lints]
 workspace = true

--- a/eyeball-im-util/Cargo.toml
+++ b/eyeball-im-util/Cargo.toml
@@ -18,8 +18,8 @@ imbl = "2.0.0"
 pin-project-lite = "0.2.9"
 
 [dev-dependencies]
-stream_assert.workspace = true
 eyeball = { version = "0.8.6", path = "../eyeball" }
+stream_assert.workspace = true
 
 [lints]
 workspace = true

--- a/eyeball-im-util/src/vector.rs
+++ b/eyeball-im-util/src/vector.rs
@@ -1,11 +1,15 @@
 //! Utilities around [`ObservableVector`][eyeball_im::ObservableVector].
 
 mod filter;
+mod limit;
 
 use eyeball_im::VectorDiff;
 use futures_core::Stream;
 
-pub use self::filter::{Filter, FilterMap};
+pub use self::{
+    filter::{Filter, FilterMap},
+    limit::DynamicLimit,
+};
 
 /// Abstraction over stream items that the adapters in this module can deal
 /// with.
@@ -42,6 +46,10 @@ pub type VectorDiffContainerStreamMappedItem<S, U> =
 pub trait VectorDiffContainerOps<T> {
     type Family: VectorDiffContainerFamily;
 
+    fn from_item(vector_diff: VectorDiff<T>) -> Self;
+
+    fn for_each(self, f: impl FnMut(VectorDiff<T>));
+
     fn filter_map<U>(
         self,
         f: impl FnMut(VectorDiff<T>) -> Option<VectorDiff<U>>,
@@ -50,6 +58,14 @@ pub trait VectorDiffContainerOps<T> {
 
 impl<T> VectorDiffContainerOps<T> for VectorDiff<T> {
     type Family = VectorDiffFamily;
+
+    fn from_item(vector_diff: VectorDiff<T>) -> Self {
+        vector_diff
+    }
+
+    fn for_each(self, mut f: impl FnMut(VectorDiff<T>)) {
+        f(self);
+    }
 
     fn filter_map<U>(
         self,
@@ -61,6 +77,14 @@ impl<T> VectorDiffContainerOps<T> for VectorDiff<T> {
 
 impl<T> VectorDiffContainerOps<T> for Vec<VectorDiff<T>> {
     type Family = VecVectorDiffFamily;
+
+    fn from_item(vector_diff: VectorDiff<T>) -> Self {
+        vec![vector_diff]
+    }
+
+    fn for_each(self, f: impl FnMut(VectorDiff<T>)) {
+        self.into_iter().for_each(f);
+    }
 
     fn filter_map<U>(
         self,

--- a/eyeball-im-util/src/vector.rs
+++ b/eyeball-im-util/src/vector.rs
@@ -3,6 +3,8 @@
 mod filter;
 mod limit;
 
+use std::collections::VecDeque;
+
 use eyeball_im::VectorDiff;
 use futures_core::Stream;
 
@@ -48,6 +50,10 @@ pub trait VectorDiffContainerOps<T> {
 
     fn from_item(vector_diff: VectorDiff<T>) -> Self;
 
+    fn pick_item(vector_diffs: &mut VecDeque<Self>) -> Option<Self>
+    where
+        Self: Sized;
+
     fn for_each(self, f: impl FnMut(VectorDiff<T>));
 
     fn filter_map<U>(
@@ -61,6 +67,13 @@ impl<T> VectorDiffContainerOps<T> for VectorDiff<T> {
 
     fn from_item(vector_diff: VectorDiff<T>) -> Self {
         vector_diff
+    }
+
+    fn pick_item(vector_diffs: &mut VecDeque<Self>) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        vector_diffs.pop_front()
     }
 
     fn for_each(self, mut f: impl FnMut(VectorDiff<T>)) {
@@ -80,6 +93,13 @@ impl<T> VectorDiffContainerOps<T> for Vec<VectorDiff<T>> {
 
     fn from_item(vector_diff: VectorDiff<T>) -> Self {
         vec![vector_diff]
+    }
+
+    fn pick_item(vector_diffs: &mut VecDeque<Self>) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        Some(vector_diffs.drain(..).flatten().collect())
     }
 
     fn for_each(self, f: impl FnMut(VectorDiff<T>)) {

--- a/eyeball-im-util/src/vector/limit.rs
+++ b/eyeball-im-util/src/vector/limit.rs
@@ -1,0 +1,359 @@
+use std::{
+    cmp::{min, Ordering},
+    collections::VecDeque,
+    pin::Pin,
+    task::{self, ready, Poll},
+};
+
+use super::{
+    VectorDiffContainer, VectorDiffContainerFamily, VectorDiffContainerOps,
+    VectorDiffContainerStreamElement, VectorDiffContainerStreamFamily,
+};
+use eyeball_im::VectorDiff;
+use futures_core::Stream;
+use imbl::{vector, Vector};
+use pin_project_lite::pin_project;
+
+pin_project! {
+    /// A [`VectorDiff`] stream adapter that presents a limited view of the
+    /// underlying [`ObservableVector`]s items.
+    ///
+    /// For example, let `S` be a `Stream<Item = VectorDiff>`. The `Vector` represented
+    /// by `S` can have any length, but one may want to virtually _limit_ this `Vector`
+    /// to a certain size. Then this `DynamicLimit` adapter is well appropriate.
+    /// The limit is dynamic, i.e. it changes over time based on values that are polled
+    /// from another `Stream` (ref. [`Self::limit_stream`]).
+    ///
+    /// Because the limit is dynamic, an internal buffered vector is kept, so that
+    /// the adapter knows which values can be added when the limit is increased, or
+    /// when values are removed and new values must be inserted. This fact is important
+    /// if the items of the `Vector` have a non-negligible size.
+    ///
+    /// It's OK to have a limit larger than the length of the observed `Vector`.
+    #[project = DynamicLimitProj]
+    pub struct DynamicLimit<S, L>
+    where
+        S: Stream,
+        S::Item: VectorDiffContainer,
+    {
+        // The main stream to poll items from.
+        #[pin]
+        inner_stream: S,
+
+        // The limit stream to poll new limits from.
+        #[pin]
+        limit_stream: L,
+
+        // The buffered vector that is updated with the main stream's items. It's
+        // used to provide missing items, e.g. when the limit increases.
+        buffered_vector: Vector<VectorDiffContainerStreamElement<S>>,
+
+        // The current limit.
+        limit: usize,
+
+        // This adapter is not a basic filter: It can produce items. For example, if the
+        // vector is [10, 11, 12, 13], with a limit of 2; then if an item is popped
+        // at the front, 10 is removed, but 12 is pushed back as it “enters” the “view”. That's
+        // 2 items to produce. This field contains all items that must be polled before
+        // anything.
+        ready_values: VecDeque<S::Item>,
+    }
+}
+
+impl<S, L> DynamicLimit<S, L>
+where
+    S: Stream,
+    S::Item: VectorDiffContainer,
+    VectorDiffContainerStreamElement<S>: Clone + Send + Sync + 'static,
+    VectorDiffContainerStreamFamily<S>:
+        VectorDiffContainerFamily<Member<VectorDiffContainerStreamElement<S>> = S::Item>,
+    L: Stream<Item = usize>,
+{
+    /// Create a new [`DynamicLimit`] with the given (unlimited) initial values,
+    /// stream of `VectorDiff` updates for those values, and a stream of
+    /// limits.
+    ///
+    /// Note that this adapter won't produce anything until a new limit is
+    /// polled.
+    pub fn new(
+        initial_values: Vector<VectorDiffContainerStreamElement<S>>,
+        inner_stream: S,
+        limit_stream: L,
+    ) -> Self {
+        Self {
+            inner_stream,
+            limit_stream,
+            buffered_vector: initial_values,
+            limit: 0,
+            ready_values: VecDeque::new(),
+        }
+    }
+}
+
+impl<S, L> Stream for DynamicLimit<S, L>
+where
+    S: Stream,
+    S::Item: VectorDiffContainer,
+    VectorDiffContainerStreamElement<S>: Clone + Send + Sync + 'static,
+    L: Stream<Item = usize>,
+{
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project().poll_next(cx)
+    }
+}
+
+impl<S, L> DynamicLimitProj<'_, S, L>
+where
+    S: Stream,
+    S::Item: VectorDiffContainer,
+    VectorDiffContainerStreamElement<S>: Clone + Send + Sync + 'static,
+    L: Stream<Item = usize>,
+{
+    fn poll_next(&mut self, cx: &mut task::Context<'_>) -> Poll<Option<S::Item>> {
+        // First off, if any value is ready, let's return it.
+        if let Some(ready_value) = self.ready_values.pop_front() {
+            return Poll::Ready(Some(ready_value));
+        }
+
+        // Let's poll a new limit from `limit_stream` before polling `inner_stream`.
+        if let Poll::Ready(Some(next_limit)) = self.limit_stream.as_mut().poll_next(cx) {
+            // We have new `VectorDiff`s after the limit has been updated. Let's
+            // return them.
+            if let Some(diffs) = self.update_limit(next_limit) {
+                return Poll::Ready(Some(diffs));
+            }
+        }
+
+        // Now, let's poll `VectorDiff`s from the `inner_stream`.
+        let Some(diffs) = ready!(self.inner_stream.as_mut().poll_next(cx)) else {
+            return Poll::Ready(None);
+        };
+
+        // Now, let's consume and apply the diffs if possible.
+        diffs.for_each(|diff| self.apply_diff(diff));
+
+        // If any value is ready, let's return it.
+        match self.ready_values.pop_front() {
+            Some(diff) => Poll::Ready(Some(diff)),
+            None => Poll::Pending,
+        }
+    }
+
+    fn apply_diff(&mut self, diff: VectorDiff<VectorDiffContainerStreamElement<S>>) {
+        let limit = *self.limit;
+        let length = self.buffered_vector.len();
+
+        // Let's update the `buffered_vector`. It's a replica of the original observed
+        // `Vector`. We need to maintain it in order to be able to produce valid
+        // `VectorDiff`s when items are missing.
+        self.update_buffered_vector(&diff);
+
+        // If the limit is zero, we have nothing to do.
+        if limit == 0 {
+            return;
+        }
+
+        let is_full = length >= limit;
+        let has_values_after_limit = length > limit;
+
+        match diff {
+            VectorDiff::Append { mut values } => {
+                if is_full {
+                    // Let's ignore the diff.
+                } else {
+                    // Let's truncate the `values` to fit inside the free space.
+                    values.truncate(min(limit - length, values.len()));
+                    self.push_ready_value(VectorDiff::Append { values });
+                }
+            }
+            VectorDiff::Clear => {
+                self.push_ready_value(VectorDiff::Clear);
+            }
+            VectorDiff::PushFront { value } => {
+                if is_full {
+                    // Create 1 free space.
+                    self.push_ready_value(VectorDiff::PopBack);
+                }
+
+                // There is space for this new item.
+                self.push_ready_value(VectorDiff::PushFront { value });
+            }
+            VectorDiff::PushBack { value } => {
+                if is_full {
+                    // Let's ignore the diff.
+                } else {
+                    // There is space for this new item.
+                    self.push_ready_value(VectorDiff::PushBack { value });
+                }
+            }
+            VectorDiff::PopFront => {
+                self.push_ready_value(VectorDiff::PopFront);
+
+                if has_values_after_limit {
+                    // Push back a new item.
+                    self.push_ready_value(VectorDiff::PushBack {
+                        // SAFETY: It's safe to `unwrap` here as we are sure a value exists at index
+                        // `limit - 1`. We are also sure that `limit > 1`.
+                        value: self.buffered_vector.get(limit - 1).unwrap().clone(),
+                    });
+                }
+            }
+            VectorDiff::PopBack => {
+                if has_values_after_limit {
+                    // Pop back outside the limit, let's ignore the diff.
+                } else {
+                    self.push_ready_value(VectorDiff::PopBack);
+                }
+            }
+            VectorDiff::Insert { index, value } => {
+                if index >= limit {
+                    // Insert after `limit`, let's ignore the diff.
+                } else {
+                    if is_full {
+                        // Create 1 free space.
+                        self.push_ready_value(VectorDiff::PopBack);
+                    }
+
+                    // There is space for this new item.
+                    self.push_ready_value(VectorDiff::Insert { index, value });
+                }
+            }
+            VectorDiff::Set { index, value } => {
+                if index >= limit {
+                    // Update after `limit`, let's ignore the diff.
+                } else {
+                    self.push_ready_value(VectorDiff::Set { index, value });
+                }
+            }
+            VectorDiff::Remove { index } => {
+                if index >= limit {
+                    // Remove after `limit`, let's ignore the diff.
+                } else {
+                    self.push_ready_value(VectorDiff::Remove { index });
+
+                    if has_values_after_limit {
+                        self.push_ready_value(VectorDiff::PushBack {
+                            // SAFETY: It's safe to `unwrap` here as we are sure a value exists at
+                            // index `limit - 1`. We are also sure that
+                            // `limit > 1`.
+                            value: self.buffered_vector.get(limit - 1).unwrap().clone(),
+                        });
+                    }
+                }
+            }
+            VectorDiff::Truncate { length: new_length } => {
+                if new_length >= limit {
+                    // Truncate items after `limit`, let's ignore the diff.
+                } else {
+                    self.push_ready_value(VectorDiff::Truncate { length: new_length });
+                }
+            }
+            VectorDiff::Reset { values: mut new_values } => {
+                if new_values.len() > limit {
+                    // There are too many values, truncate.
+                    new_values.truncate(limit);
+                }
+
+                // There is space for these new items.
+                self.push_ready_value(VectorDiff::Reset { values: new_values });
+            }
+        }
+    }
+
+    fn push_ready_value(&mut self, diff: VectorDiff<VectorDiffContainerStreamElement<S>>) {
+        self.ready_values.push_back(S::Item::from_item(diff));
+    }
+
+    /// Update the buffered vector.
+    ///
+    /// All items are cloned.
+    fn update_buffered_vector(&mut self, diff: &VectorDiff<VectorDiffContainerStreamElement<S>>) {
+        match diff {
+            VectorDiff::Append { values } => self.buffered_vector.append(values.clone()),
+            VectorDiff::Clear => self.buffered_vector.clear(),
+            VectorDiff::PushFront { value } => self.buffered_vector.push_front(value.clone()),
+            VectorDiff::PushBack { value } => self.buffered_vector.push_back(value.clone()),
+            VectorDiff::PopFront => {
+                self.buffered_vector.pop_front();
+            }
+            VectorDiff::PopBack => {
+                self.buffered_vector.pop_back();
+            }
+            VectorDiff::Insert { index, value } => {
+                self.buffered_vector.insert(*index, value.clone());
+            }
+            VectorDiff::Set { index, value } => {
+                self.buffered_vector.set(*index, value.clone());
+            }
+            VectorDiff::Remove { index } => {
+                self.buffered_vector.remove(*index);
+            }
+            VectorDiff::Truncate { length } => self.buffered_vector.truncate(*length),
+            VectorDiff::Reset { values } => {
+                *self.buffered_vector = values.clone();
+            }
+        }
+    }
+
+    /// Update the limit if necessary.
+    ///
+    /// * If the buffered vector is empty, it returns `None`.
+    /// * If the limit increases, a `VectorDiff::Append` is produced if any
+    ///   items exist.
+    /// * If the limit decreases below the length of the vector, a
+    ///   `VectorDiff::Truncate` is produced.
+    ///
+    /// It's OK to have a `new_limit` larger than the length of the `Vector`.
+    /// The `new_limit` won't be capped.
+    fn update_limit(&mut self, next_limit: usize) -> Option<S::Item> {
+        if self.buffered_vector.is_empty() {
+            // Let's update the limit.
+            *self.limit = next_limit;
+
+            // But let's ignore any update.
+            return None;
+        }
+
+        match (*self.limit).cmp(&next_limit) {
+            // old < new
+            Ordering::Less => {
+                // Let's add the missing items.
+                let mut missing_items = vector![];
+
+                for nth in *self.limit..min(self.buffered_vector.len(), next_limit) {
+                    // SAFETY: It's OK to `unwrap` here as we are sure we are iterating over defined
+                    // items.
+                    let item = self.buffered_vector.get(nth).unwrap();
+                    missing_items.push_back(item.clone());
+                }
+
+                // Let's update the limit.
+                *self.limit = next_limit;
+
+                let missing_items =
+                    S::Item::from_item(VectorDiff::Append { values: missing_items });
+
+                Some(missing_items)
+            }
+
+            // old > new
+            Ordering::Greater => {
+                // Let's remove the extra items.
+                let items_removal = S::Item::from_item(VectorDiff::Truncate { length: next_limit });
+
+                // Let's update the limit.
+                *self.limit = next_limit;
+
+                Some(items_removal)
+            }
+
+            // old == new
+            Ordering::Equal => {
+                // Nothing to do.
+                None
+            }
+        }
+    }
+}

--- a/eyeball-im-util/tests/it/limit.rs
+++ b/eyeball-im-util/tests/it/limit.rs
@@ -75,6 +75,18 @@ fn increase_and_decrease_the_limit_only() {
     // Observe 2 more values.
     assert_next_eq!(sub, VectorDiff::Append { values: vector![12, 13] });
 
+    // Set limit to 6.
+    Observable::set(&mut limit, 6);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Set limit to 5.
+    Observable::set(&mut limit, 5);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
     // Set limit to 1.
     Observable::set(&mut limit, 1);
 

--- a/eyeball-im-util/tests/it/limit.rs
+++ b/eyeball-im-util/tests/it/limit.rs
@@ -1,0 +1,721 @@
+use eyeball::Observable;
+use eyeball_im::{ObservableVector, VectorDiff};
+use eyeball_im_util::vector::DynamicLimit;
+use imbl::vector;
+use stream_assert::{assert_closed, assert_next_eq, assert_pending};
+
+#[test]
+fn pending_until_limit_emits_a_value() {
+    let mut ob: ObservableVector<usize> = ObservableVector::new();
+    let mut limit = Observable::new(0);
+    let mut sub =
+        DynamicLimit::new(ob.clone(), ob.subscribe().into_stream(), Observable::subscribe(&limit));
+
+    // Append new values…
+    ob.append(vector![10, 11, 12]);
+
+    // … but it's still pending…
+    assert_pending!(sub);
+
+    // … because the `limit` stream didn't produce any value yet.
+    // Let's change that.
+    Observable::set(&mut limit, 7);
+
+    // Here we are.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![10, 11, 12] });
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn increase_and_decrease_the_limit_on_an_empty_stream() {
+    let ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub =
+        DynamicLimit::new(ob.clone(), ob.subscribe().into_stream(), Observable::subscribe(&limit));
+
+    // `ob` is empty!
+
+    // Set limit to 2.
+    Observable::set(&mut limit, 2);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Set limit to 1.
+    Observable::set(&mut limit, 1);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn increase_and_decrease_the_limit_only() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub =
+        DynamicLimit::new(ob.clone(), ob.subscribe().into_stream(), Observable::subscribe(&limit));
+
+    // Append 4 values.
+    ob.append(vector![10, 11, 12, 13]);
+
+    // Set limit to 2.
+    Observable::set(&mut limit, 2);
+
+    // Observe 2 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![10, 11] });
+
+    // Set limit to 4.
+    Observable::set(&mut limit, 4);
+
+    // Observe 2 more values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![12, 13] });
+
+    // Set limit to 1.
+    Observable::set(&mut limit, 1);
+
+    // Observe a truncation.
+    assert_next_eq!(sub, VectorDiff::Truncate { length: 1 });
+
+    // Set limit to 0.
+    Observable::set(&mut limit, 0);
+
+    // Observe another truncation.
+    assert_next_eq!(sub, VectorDiff::Truncate { length: 0 });
+
+    // Set limit to 5.
+    Observable::set(&mut limit, 5);
+
+    // Observe all available values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![10, 11, 12, 13] });
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn limit_is_zero() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub =
+        DynamicLimit::new(ob.clone(), ob.subscribe().into_stream(), Observable::subscribe(&limit));
+
+    // Append 4 values.
+    ob.append(vector![10, 11, 12, 13]);
+
+    // Set limit to 0.
+    Observable::set(&mut limit, 0);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Add 1 value.
+    ob.push_back(14);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Set limit to 5.
+    Observable::set(&mut limit, 5);
+
+    // Observe 5 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![10, 11, 12, 13, 14] });
+
+    // Set limit to 0 again.
+    Observable::set(&mut limit, 0);
+
+    // Observe a truncation.
+    assert_next_eq!(sub, VectorDiff::Truncate { length: 0 });
+
+    // Add 1 value.
+    ob.push_back(15);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn limit_is_polled_first() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub =
+        DynamicLimit::new(ob.clone(), ob.subscribe().into_stream(), Observable::subscribe(&limit));
+
+    // Append 4 values.
+    ob.append(vector![10, 11, 12, 13]);
+
+    // Set limit to 3.
+    Observable::set(&mut limit, 3);
+
+    // Observe 3 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![10, 11, 12] });
+
+    // Add 1 value on the front…
+    ob.push_front(14);
+
+    // … and set limit to 2 _after_.
+    Observable::set(&mut limit, 2);
+
+    // However, let's observe the limit's change _first_…
+    assert_next_eq!(sub, VectorDiff::Truncate { length: 2 });
+
+    // … and let's observe the other updates _after_.
+    assert_next_eq!(sub, VectorDiff::PopBack);
+    assert_next_eq!(sub, VectorDiff::PushFront { value: 14 });
+    assert_pending!(sub);
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn append() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub =
+        DynamicLimit::new(ob.clone(), ob.subscribe().into_stream(), Observable::subscribe(&limit));
+
+    // Set limit to 4.
+    Observable::set(&mut limit, 4);
+
+    // Append 3 values.
+    ob.append(vector![10, 11, 12]);
+
+    // Observe 3 more values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![10, 11, 12] });
+
+    // Append 3 more values, whom 2 are outside the limit.
+    ob.append(vector![13, 14, 15]);
+
+    // Observe only 1 value.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![13] });
+
+    // Set limit to 8.
+    Observable::set(&mut limit, 8);
+
+    // Observe the other 2 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![14, 15] });
+
+    // Append 2 more values to reach the limit.
+    ob.append(vector![16, 17]);
+
+    // Observe 2 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![16, 17] });
+
+    // Append 2 more values, that are outside the limit.
+    ob.append(vector![18, 19]);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Check the content of the vector.
+    {
+        let expected = vector![10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Truncate { length: 0 });
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn clear() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub =
+        DynamicLimit::new(ob.clone(), ob.subscribe().into_stream(), Observable::subscribe(&limit));
+
+    // Set limit to 4.
+    Observable::set(&mut limit, 4);
+
+    // Add 1 value.
+    ob.push_back(10);
+
+    // Clear.
+    ob.clear();
+
+    // Observe the updates.
+    assert_next_eq!(sub, VectorDiff::PushBack { value: 10 });
+    assert_next_eq!(sub, VectorDiff::Clear);
+
+    // Check the content of the vector.
+    {
+        let expected = vector![];
+        assert_eq!(*ob, expected);
+    }
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn push_front() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub =
+        DynamicLimit::new(ob.clone(), ob.subscribe().into_stream(), Observable::subscribe(&limit));
+
+    // Set limit to 2.
+    Observable::set(&mut limit, 2);
+
+    // Add 1 value.
+    ob.push_front(10);
+
+    // Observe 1 value.
+    assert_next_eq!(sub, VectorDiff::PushFront { value: 10 });
+
+    // Add 1 value.
+    ob.push_front(11);
+
+    // Observe 1 value.
+    assert_next_eq!(sub, VectorDiff::PushFront { value: 11 });
+
+    // Add 1 value.
+    ob.push_front(12);
+
+    // Observe 1 value being removed, and 1 new value.
+    assert_next_eq!(sub, VectorDiff::PopBack);
+    assert_next_eq!(sub, VectorDiff::PushFront { value: 12 });
+
+    // Add 1 value.
+    ob.push_front(13);
+
+    // Observe 1 value being removed, and 1 new value.
+    assert_next_eq!(sub, VectorDiff::PopBack);
+    assert_next_eq!(sub, VectorDiff::PushFront { value: 13 });
+    assert_pending!(sub);
+
+    // Check the content of the vector.
+    {
+        let expected = vector![13, 12, 11, 10];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Truncate { length: 0 });
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn push_back() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub =
+        DynamicLimit::new(ob.clone(), ob.subscribe().into_stream(), Observable::subscribe(&limit));
+
+    // Set limit to 2.
+    Observable::set(&mut limit, 2);
+
+    // Add 1 value.
+    ob.push_back(10);
+
+    // Observe 1 value.
+    assert_next_eq!(sub, VectorDiff::PushBack { value: 10 });
+
+    // Add 1 value.
+    ob.push_back(11);
+
+    // Observe 1 value.
+    assert_next_eq!(sub, VectorDiff::PushBack { value: 11 });
+
+    // Add 1 value.
+    ob.push_back(12);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Add 1 value.
+    ob.push_back(13);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Check the content of the vector.
+    {
+        let expected = vector![10, 11, 12, 13];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Truncate { length: 0 });
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn pop_front() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub =
+        DynamicLimit::new(ob.clone(), ob.subscribe().into_stream(), Observable::subscribe(&limit));
+
+    // Add 4 values.
+    ob.append(vector![10, 11, 12, 13]);
+
+    // Set limit to 2.
+    Observable::set(&mut limit, 2);
+
+    // Observe 2 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![10, 11] });
+
+    // Remove 1 value.
+    ob.pop_front();
+
+    // Observe 1 value being removed, and 1 new value being inserted at the back.
+    assert_next_eq!(sub, VectorDiff::PopFront);
+    assert_next_eq!(sub, VectorDiff::PushBack { value: 12 });
+
+    // Remove 1 value.
+    ob.pop_front();
+
+    // Observe 1 value being removed, and 1 new value being inserted at the back.
+    assert_next_eq!(sub, VectorDiff::PopFront);
+    assert_next_eq!(sub, VectorDiff::PushBack { value: 13 });
+
+    // Remove 1 value.
+    ob.pop_front();
+
+    // Observe only 1 value being removed.
+    assert_next_eq!(sub, VectorDiff::PopFront);
+    assert_pending!(sub);
+
+    // Check the content of the vector.
+    {
+        let expected = vector![13];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Truncate { length: 0 });
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn pop_back() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub =
+        DynamicLimit::new(ob.clone(), ob.subscribe().into_stream(), Observable::subscribe(&limit));
+
+    // Add 4 values.
+    ob.append(vector![10, 11, 12, 13]);
+
+    // Set limit to 3.
+    Observable::set(&mut limit, 3);
+
+    // Observe 3 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![10, 11, 12] });
+
+    // Remove 1 value.
+    ob.pop_back();
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Remove 1 value.
+    ob.pop_back();
+
+    // Observe nothing.
+    assert_next_eq!(sub, VectorDiff::PopBack);
+
+    // Remove 1 value.
+    ob.pop_back();
+
+    // Observe nothing.
+    assert_next_eq!(sub, VectorDiff::PopBack);
+
+    // Check the content of the vector.
+    {
+        let expected = vector![10];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Truncate { length: 0 });
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn insert() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub =
+        DynamicLimit::new(ob.clone(), ob.subscribe().into_stream(), Observable::subscribe(&limit));
+
+    // Add 2 values.
+    ob.append(vector![10, 11]);
+
+    // Set limit to 3.
+    Observable::set(&mut limit, 3);
+
+    // Observe 2 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![10, 11] });
+
+    // Insert 1 value.
+    ob.insert(1, 12);
+
+    // Observe 1 value.
+    assert_next_eq!(sub, VectorDiff::Insert { index: 1, value: 12 });
+
+    // Insert 1 value.
+    ob.insert(1, 13);
+
+    // Observe 1 value being removed, and 1 value being added.
+    assert_next_eq!(sub, VectorDiff::PopBack);
+    assert_next_eq!(sub, VectorDiff::Insert { index: 1, value: 13 });
+
+    // Insert 1 value at the limit.
+    ob.insert(2, 14);
+
+    // Observe 1 value being removed, and 1 value being added.
+    assert_next_eq!(sub, VectorDiff::PopBack);
+    assert_next_eq!(sub, VectorDiff::Insert { index: 2, value: 14 });
+
+    // Insert 1 value after the limit.
+    ob.insert(4, 15);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Check the content of the vector.
+    {
+        let expected = vector![10, 13, 14, 12, 15, 11];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Truncate { length: 0 });
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn set() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub =
+        DynamicLimit::new(ob.clone(), ob.subscribe().into_stream(), Observable::subscribe(&limit));
+
+    // Add 3 values.
+    ob.append(vector![10, 11, 12]);
+
+    // Set limit to 2.
+    Observable::set(&mut limit, 2);
+
+    // Observe 2 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![10, 11] });
+
+    // Set 1 value.
+    ob.set(0, 20);
+
+    // Observe 1 update.
+    assert_next_eq!(sub, VectorDiff::Set { index: 0, value: 20 });
+
+    // Set 1 value at the limit.
+    ob.set(1, 21);
+
+    // Observe 1 update.
+    assert_next_eq!(sub, VectorDiff::Set { index: 1, value: 21 });
+
+    // Set 1 value after the limit.
+    ob.set(2, 22);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Check the content of the vector.
+    {
+        let expected = vector![20, 21, 22];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Truncate { length: 0 });
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn remove() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub =
+        DynamicLimit::new(ob.clone(), ob.subscribe().into_stream(), Observable::subscribe(&limit));
+
+    // Add 5 values.
+    ob.append(vector![10, 11, 12, 13, 14]);
+
+    // Set limit to 2.
+    Observable::set(&mut limit, 2);
+
+    // Observe 2 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![10, 11] });
+
+    // Remove 1 value after the limit.
+    ob.remove(3);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Remove 1 value at the limit.
+    ob.remove(1);
+
+    // Observe 1 value being removed, and 1 new value being pushed back.
+    assert_next_eq!(sub, VectorDiff::Remove { index: 1 });
+    assert_next_eq!(sub, VectorDiff::PushBack { value: 12 });
+
+    // Remove 1 value.
+    ob.remove(0);
+
+    // Observe 1 value being removed, and 1 new value being pushed back.
+    assert_next_eq!(sub, VectorDiff::Remove { index: 0 });
+    assert_next_eq!(sub, VectorDiff::PushBack { value: 14 });
+    assert_pending!(sub);
+
+    // Check the content of the vector.
+    {
+        let expected = vector![12, 14];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Truncate { length: 0 });
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn truncate() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub =
+        DynamicLimit::new(ob.clone(), ob.subscribe().into_stream(), Observable::subscribe(&limit));
+
+    // Add 5 values.
+    ob.append(vector![10, 11, 12, 13, 14]);
+
+    // Set limit to 3.
+    Observable::set(&mut limit, 3);
+
+    // Observe 3 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![10, 11, 12] });
+
+    // Truncate after the limit.
+    ob.truncate(4);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Truncate at the limit.
+    ob.truncate(3);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Truncate.
+    ob.truncate(1);
+
+    // Observe truncation.
+    assert_next_eq!(sub, VectorDiff::Truncate { length: 1 });
+
+    // Check the content of the vector.
+    {
+        let expected = vector![10];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Truncate { length: 0 });
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn reset() {
+    let mut ob = ObservableVector::<usize>::with_capacity(2);
+    let mut limit = Observable::new(0);
+    let mut sub =
+        DynamicLimit::new(ob.clone(), ob.subscribe().into_stream(), Observable::subscribe(&limit));
+
+    // Add 1 value.
+    ob.append(vector![10]);
+
+    // Set limit to 4.
+    Observable::set(&mut limit, 4);
+
+    // Observe 1 value.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![10] });
+
+    // Modify many values to saturate the observable capacity, in order to trigger a
+    // reset.
+    ob.push_back(11);
+    ob.append(vector![12, 13]);
+    ob.insert(0, 14);
+
+    // Observe a reset, capped to the limit.
+    assert_next_eq!(sub, VectorDiff::Reset { values: vector![14, 10, 11, 12] });
+    assert_pending!(sub);
+
+    // Check the content of the vector.
+    {
+        let expected = vector![14, 10, 11, 12, 13];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Truncate { length: 0 });
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    drop(ob);
+    assert_closed!(sub);
+}

--- a/eyeball-im-util/tests/it/main.rs
+++ b/eyeball-im-util/tests/it/main.rs
@@ -1,2 +1,3 @@
 mod filter;
 mod filter_map;
+mod limit;


### PR DESCRIPTION
A `VectorDiff` stream adapter that presents a limited view of the
underlying `ObservableVector`s items.

For example, be `S` a `Stream<Item = VectorDiff>`. The `Vector` represented
by `S` can have any length, but one may want to virtually _limit_ this `Vector`
to a certain size. Then this `DynamicLimit` adapter is well appropriated.
The limit is dynamic, i.e. it changes over time based on values that are polled
from another `Stream` (ref. `Self::limit_stream`).

Because the limit is dynamic, an internal buffered vector is kept, so that
the adapter knows which values can be added when the limit is increased, or
when values are removed and new values must be inserted. This fact is important
if the items of the `Vector` have a non-negligeable size.

It's OK to have a limit larger than the length of the observed `Vector`.

Note that this adapter won't produce anything until a new limit is polled.