### PR TITLE
im-util: Rename DynamicLimit => Limit and add more constructors

### DIFF
--- a/eyeball-im-util/CHANGELOG.md
+++ b/eyeball-im-util/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Add `Limit` adapter for presenting a limited view of an underlying observable
+  vector
+
 # 0.3.1
 
 - Fix a bug with `Filter` and `FilterMap` that was corrupting their internal

--- a/eyeball-im-util/src/vector.rs
+++ b/eyeball-im-util/src/vector.rs
@@ -10,7 +10,7 @@ use futures_core::Stream;
 
 pub use self::{
     filter::{Filter, FilterMap},
-    limit::DynamicLimit,
+    limit::{EmptyLimitStream, Limit},
 };
 
 /// Abstraction over stream items that the adapters in this module can deal


### PR DESCRIPTION
- DynamicLimit => Limit because  the limit can be static
- DynamicLimit::new => Limit::dynamic
- Limit::new for a static limit constructor
- Limit::dynamic_with_initial_limit for starting with a non-empty vector