### PR TITLE
fix(im): `ObservableVecto::clear` emits a `VectorDiff::Clear` when necessary

### DIFF
--- a/eyeball-im/src/vector.rs
+++ b/eyeball-im/src/vector.rs
@@ -80,10 +80,16 @@ impl<T: Clone + Send + Sync + 'static> ObservableVector<T> {
 
     /// Clear out all of the elements in this `Vector` and notify subscribers.
     pub fn clear(&mut self) {
-        #[cfg(feature = "tracing")]
-        tracing::debug!(target: "eyeball_im::vector::update", "clear");
+        let already_empty = self.values.is_empty();
 
-        if !self.values.is_empty() {
+        #[cfg(feature = "tracing")]
+        tracing::debug!(
+            target: "eyeball_im::vector::update",
+            nop = already_empty.then_some(true),
+            "clear"
+        );
+
+        if !already_empty {
             self.values.clear();
             self.broadcast_diff(VectorDiff::Clear);
         }

--- a/eyeball-im/src/vector.rs
+++ b/eyeball-im/src/vector.rs
@@ -83,8 +83,10 @@ impl<T: Clone + Send + Sync + 'static> ObservableVector<T> {
         #[cfg(feature = "tracing")]
         tracing::debug!(target: "eyeball_im::vector::update", "clear");
 
-        self.values.clear();
-        self.broadcast_diff(VectorDiff::Clear);
+        if !self.values.is_empty() {
+            self.values.clear();
+            self.broadcast_diff(VectorDiff::Clear);
+        }
     }
 
     /// Add an element at the front of the list and notify subscribers.

--- a/eyeball-im/tests/it/main.rs
+++ b/eyeball-im/tests/it/main.rs
@@ -1,5 +1,5 @@
 use imbl::{vector, Vector};
-use stream_assert::{assert_next_eq, assert_pending};
+use stream_assert::{assert_closed, assert_next_eq, assert_pending};
 
 use eyeball_im::{ObservableVector, ObservableVectorEntry, VectorDiff};
 
@@ -56,6 +56,25 @@ fn truncate() {
     ob.truncate(0);
     assert_next_eq!(sub, VectorDiff::Truncate { length: 0 });
     assert!(ob.is_empty());
+}
+
+#[test]
+fn clear() {
+    let mut ob: ObservableVector<i32> = ObservableVector::from(vector![1, 2]);
+    let mut sub = ob.subscribe().into_stream();
+    assert_pending!(sub);
+
+    ob.clear();
+    assert_next_eq!(sub, VectorDiff::Clear);
+    assert!(ob.is_empty());
+
+    // Clearing again. The vector is empty now. We don't expect a
+    // `VectorDiff::Clear`.
+    ob.clear();
+    assert_pending!(sub);
+
+    drop(ob);
+    assert_closed!(sub);
 }
 
 #[test]


### PR DESCRIPTION
The idea behind this patch is to avoid emitting a `VectorDiff::Clear` when an `ObservableVector` is already empty.

Thoughts?