### PR TITLE
feat(im): Add support for `serde` in `eyeball-im`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test
+      - run: cargo test --all-features
 
   docs:
     name: Check documentation (Rust stable)
@@ -55,7 +55,7 @@ jobs:
         with:
           components: miri
       - uses: Swatinem/rust-cache@v2
-      - run: cargo miri test
+      - run: cargo miri test --all-features
         env:
           # Enable Tree Borrows, Stacked Borrows is weirdly restrictive
           # https://github.com/jneem/imbl/issues/59#issuecomment-1569746186
@@ -71,7 +71,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy --all-features -- -D warnings
 
   typos:
     name: Spell Check with Typos

--- a/eyeball-im/Cargo.toml
+++ b/eyeball-im/Cargo.toml
@@ -14,12 +14,19 @@ all-features = true
 [dependencies]
 futures-core.workspace = true
 imbl = "2.0.0"
+serde = { version = "1.0", optional = true }
 tokio.workspace = true
 tokio-util.workspace = true
 tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
+serde_json = "1.0"
 stream_assert.workspace = true
+
+[features]
+default = []
+# Enable this feature to implement `serde::Serialize` for `VectorDiff`.
+serde = ["dep:serde", "imbl/serde"]
 
 [lints]
 workspace = true

--- a/eyeball-im/src/vector.rs
+++ b/eyeball-im/src/vector.rs
@@ -461,6 +461,76 @@ impl<T: Clone> VectorDiff<T> {
     }
 }
 
+#[cfg(feature = "serde")]
+impl<T> serde::Serialize for VectorDiff<T>
+where
+    T: serde::Serialize + Clone,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStructVariant;
+
+        const SELF_NAME: &str = "VectorDiff";
+
+        match self {
+            Self::Append { values } => {
+                let mut state = serializer.serialize_struct_variant(SELF_NAME, 0, "Append", 1)?;
+                state.serialize_field("values", values)?;
+                state.end()
+            }
+            VectorDiff::Clear => {
+                serializer.serialize_struct_variant(SELF_NAME, 1, "Clear", 0)?.end()
+            }
+            VectorDiff::PushFront { value } => {
+                let mut state =
+                    serializer.serialize_struct_variant(SELF_NAME, 2, "PushFront", 1)?;
+                state.serialize_field("value", value)?;
+                state.end()
+            }
+            VectorDiff::PushBack { value } => {
+                let mut state = serializer.serialize_struct_variant(SELF_NAME, 3, "PushBack", 1)?;
+                state.serialize_field("value", value)?;
+                state.end()
+            }
+            VectorDiff::PopFront => {
+                serializer.serialize_struct_variant(SELF_NAME, 4, "PopFront", 0)?.end()
+            }
+            VectorDiff::PopBack => {
+                serializer.serialize_struct_variant(SELF_NAME, 5, "PopBack", 0)?.end()
+            }
+            VectorDiff::Insert { index, value } => {
+                let mut state = serializer.serialize_struct_variant(SELF_NAME, 6, "Insert", 2)?;
+                state.serialize_field("index", index)?;
+                state.serialize_field("value", value)?;
+                state.end()
+            }
+            VectorDiff::Set { index, value } => {
+                let mut state = serializer.serialize_struct_variant(SELF_NAME, 7, "Set", 2)?;
+                state.serialize_field("index", index)?;
+                state.serialize_field("value", value)?;
+                state.end()
+            }
+            VectorDiff::Remove { index } => {
+                let mut state = serializer.serialize_struct_variant(SELF_NAME, 8, "Remove", 1)?;
+                state.serialize_field("index", index)?;
+                state.end()
+            }
+            VectorDiff::Truncate { length } => {
+                let mut state = serializer.serialize_struct_variant(SELF_NAME, 9, "Truncate", 1)?;
+                state.serialize_field("length", length)?;
+                state.end()
+            }
+            VectorDiff::Reset { values } => {
+                let mut state = serializer.serialize_struct_variant(SELF_NAME, 10, "Reset", 1)?;
+                state.serialize_field("values", values)?;
+                state.end()
+            }
+        }
+    }
+}
+
 fn vector_map<T: Clone, U: Clone>(v: Vector<T>, f: impl FnMut(T) -> U) -> Vector<U> {
     v.into_iter().map(f).collect()
 }

--- a/eyeball-im/tests/it/main.rs
+++ b/eyeball-im/tests/it/main.rs
@@ -6,6 +6,8 @@ use eyeball_im::{ObservableVector, ObservableVectorEntry, VectorDiff};
 mod apply;
 mod batch;
 mod entry;
+#[cfg(feature = "serde")]
+mod serde;
 
 #[test]
 fn lag() {

--- a/eyeball-im/tests/it/serde.rs
+++ b/eyeball-im/tests/it/serde.rs
@@ -1,0 +1,28 @@
+use eyeball_im::VectorDiff;
+use imbl::vector;
+
+macro_rules! test {
+    ($test_name:ident: $vector_diff:expr => $json:expr) => {
+        #[test]
+        fn $test_name() -> Result<(), Box<dyn std::error::Error>> {
+            let vector_diff: VectorDiff<char> = $vector_diff;
+            let json = serde_json::to_string(&vector_diff)?;
+
+            assert_eq!(json, $json);
+
+            Ok(())
+        }
+    };
+}
+
+test!(append: VectorDiff::Append { values: vector!['a', 'b'] } => r#"{"Append":{"values":["a","b"]}}"#);
+test!(clear: VectorDiff::Clear => r#"{"Clear":{}}"#);
+test!(push_front: VectorDiff::PushFront { value: 'a' } => r#"{"PushFront":{"value":"a"}}"#);
+test!(push_back: VectorDiff::PushBack { value: 'a' } => r#"{"PushBack":{"value":"a"}}"#);
+test!(pop_front: VectorDiff::PopFront => r#"{"PopFront":{}}"#);
+test!(pop_back: VectorDiff::PopBack => r#"{"PopBack":{}}"#);
+test!(insert: VectorDiff::Insert { index: 42, value: 'a' } => r#"{"Insert":{"index":42,"value":"a"}}"#);
+test!(set: VectorDiff::Set { index: 42, value: 'a' } => r#"{"Set":{"index":42,"value":"a"}}"#);
+test!(remove: VectorDiff::Remove { index: 42 } => r#"{"Remove":{"index":42}}"#);
+test!(truncate: VectorDiff::Truncate { length: 3 } => r#"{"Truncate":{"length":3}}"#);
+test!(reset: VectorDiff::Reset { values: vector!['a', 'b'] } => r#"{"Reset":{"values":["a","b"]}}"#);


### PR DESCRIPTION
This patch adds the `serde` feature, which —when turned on— implements
`serde::Serialize` for `VectorDiff`.

This is a custom `serde::Serialize` implementation because the `derive`
macro cannot be used here, since it requires `T` in `VectorDiff<T>` to
implement `serde::Serialize` and `Clone`. These constraints must not be
present on the `VectorDiff` enum definition.

This patch also adds a test suite: it tests that all `VectorDiff`'s
variants can be serialized to JSON for example.

Note that `VectorDiff` doesn't implement `serde::Deserialize` because
it's not necessary: `eyeball-im` only _emits_ `VectorDiff`s, it cannot
receive them.