### PR TITLE
feat(im-util): `SortBy` optimises `Remove` + `Insert` to `Set` in another case

### DIFF
--- a/eyeball-im-util/tests/it/sort.rs
+++ b/eyeball-im-util/tests/it/sort.rs
@@ -338,9 +338,17 @@ fn set() {
     ob.set(0, 'd');
     assert_next_eq!(sub, VectorDiff::Set { index: 1, value: 'd' });
 
-    // Another value, that is sorted at the same index.
+    // Another value, that is sorted at the same sorted index: `d` is at the sorted
+    // index 1, and `c` is at the sorted index 1 too. The `VectorDiff::Remove` +
+    // `VectorDiff::Insert` are optimised as a single `VectorDiff::Set`.
     ob.set(0, 'c');
     assert_next_eq!(sub, VectorDiff::Set { index: 1, value: 'c' });
+
+    // Another value, that is sorted at an adjacent sorted index: `c` is at the
+    // sorted index 1, but `d` is at the sorted index 2. The `VectorDiff::Remove` +
+    // `VectorDiff::Insert` are optimised as a single `VectorDiff::Set`.
+    ob.set(0, 'd');
+    assert_next_eq!(sub, VectorDiff::Set { index: 1, value: 'd' });
 
     // Another value, that is moved to the left.
     ob.set(0, 'a');


### PR DESCRIPTION
In the `SortBy` stream adapter, when the user is applying a `observable_vector.set(…)` that should result in a `Remove` + `Insert`, it sometimes can be optimised into a single `Set`. This happens when the `old_index` and the `new_index` (resp. the sorted index of the value to be updated, and the sorted index of the new value) are equal. But actually, when `old_index` is lower than `new_index`, there is _another_ missed optimisation in one particular context. If `old_index == new_index - 1`, then we are actually updating the same location. Indeed, the code is already making it clear: when `old_index < new_index`, we need to subtract 1 to `new_index` because removing the value at `old_index` is shifting all values at its right, thus 1 must be subtracted to `new_index`. The missed opportunity for an optimisation here is when `old_index == new_index - 1`, where it's clear that the same position is updated. This patch handles this situation. The tests are updated accordingly.

Thanks @jplatte for having found this in https://github.com/jplatte/eyeball/pull/46#issuecomment-1982020069.