### PR TITLE
Make eyeball tests independent of tokio

### DIFF
--- a/eyeball/Cargo.toml
+++ b/eyeball/Cargo.toml
@@ -25,7 +25,9 @@ tokio-util = { version = "0.7.8", optional = true }
 divan = { version = "0.1.14", optional = true }
 
 [dev-dependencies]
+futures-executor = "0.3.30"
 futures-util.workspace = true
+macro_rules_attribute = "0.2.0"
 stream_assert.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 

--- a/eyeball/tests/it/main.rs
+++ b/eyeball/tests/it/main.rs
@@ -1,3 +1,18 @@
+macro_rules! test {
+    (
+        $(#[$post_attr:meta])*
+        async fn $name:ident() $(-> $ret:ty)? $bl:block
+    ) => {
+        $(#[$post_attr])*
+        #[core::prelude::v1::test]
+        fn $name () $(-> $ret)? {
+            futures_executor::block_on(async {
+                $bl
+            })
+        }
+    };
+}
+
 #[cfg(feature = "async-lock")]
 mod async_lock;
 mod shared;


### PR DESCRIPTION
This required making the `shared::separate_tasks` test less interesting, because I realized it was wrong before: It was relying on the tasks in the tokio `JoinSet` running in order, otherwise the final value being set on the observable (and thus seen by the subscriber) could be a different one from the one we assert equality with.