### PR TITLE
Wasm32 support

### DIFF
--- a/eyeball-im/src/vector.rs
+++ b/eyeball-im/src/vector.rs
@@ -2,9 +2,11 @@ use std::{fmt, ops};
 
 use imbl::Vector;
 use tokio::sync::broadcast::{self, Sender};
+use traits::{SendOutsideWasm, SyncOutsideWasm};
 
 mod entry;
 mod subscriber;
+mod traits;
 mod transaction;
 
 pub use self::{
@@ -22,7 +24,7 @@ pub struct ObservableVector<T> {
     sender: Sender<BroadcastMessage<T>>,
 }
 
-impl<T: Clone + Send + Sync + 'static> ObservableVector<T> {
+impl<T: Clone + SendOutsideWasm + SyncOutsideWasm + 'static> ObservableVector<T> {
     /// Create a new `ObservableVector`.
     ///
     /// As of the time of writing, this is equivalent to
@@ -290,7 +292,7 @@ impl<T: Clone + Send + Sync + 'static> ObservableVector<T> {
     }
 }
 
-impl<T: Clone + Send + Sync + 'static> Default for ObservableVector<T> {
+impl<T: Clone + SendOutsideWasm + SyncOutsideWasm + 'static> Default for ObservableVector<T> {
     fn default() -> Self {
         Self::new()
     }
@@ -315,7 +317,9 @@ impl<T> ops::Deref for ObservableVector<T> {
     }
 }
 
-impl<T: Clone + Send + Sync + 'static> From<Vector<T>> for ObservableVector<T> {
+impl<T: Clone + SendOutsideWasm + SyncOutsideWasm + 'static> From<Vector<T>>
+    for ObservableVector<T>
+{
     fn from(values: Vector<T>) -> Self {
         let mut this = Self::new();
         this.append(values);

--- a/eyeball-im/src/vector/entry.rs
+++ b/eyeball-im/src/vector/entry.rs
@@ -1,6 +1,9 @@
 use std::{fmt, ops::Deref};
 
-use super::ObservableVector;
+use super::{
+    traits::{SendOutsideWasm, SyncOutsideWasm},
+    ObservableVector,
+};
 
 /// A handle to a single value in an [`ObservableVector`].
 pub struct ObservableVectorEntry<'a, T> {
@@ -10,7 +13,7 @@ pub struct ObservableVectorEntry<'a, T> {
 
 impl<'a, T> ObservableVectorEntry<'a, T>
 where
-    T: Clone + Send + Sync + 'static,
+    T: Clone + SendOutsideWasm + SyncOutsideWasm + 'static,
 {
     pub(super) fn new(inner: &'a mut ObservableVector<T>, index: usize) -> Self {
         Self { inner, index: EntryIndex::Owned(index) }
@@ -115,7 +118,7 @@ pub struct ObservableVectorEntries<'a, T> {
 
 impl<'a, T> ObservableVectorEntries<'a, T>
 where
-    T: Clone + Send + Sync + 'static,
+    T: Clone + SendOutsideWasm + SyncOutsideWasm + 'static,
 {
     pub(super) fn new(inner: &'a mut ObservableVector<T>) -> Self {
         Self { inner, index: 0 }

--- a/eyeball-im/src/vector/traits.rs
+++ b/eyeball-im/src/vector/traits.rs
@@ -70,7 +70,7 @@ where
 /// This type lets you replace the future stored in the box without
 /// reallocating when the size and alignment permits this.
 #[cfg(target_arch = "wasm32")]
-pub struct ReusableBoxFuture<'a, T> {
+pub(crate) struct ReusableBoxFuture<'a, T> {
     boxed: Pin<Box<dyn Future<Output = T> + 'a>>,
 }
 
@@ -84,7 +84,7 @@ impl<'a, T> fmt::Debug for ReusableBoxFuture<'a, T> {
 #[cfg(target_arch = "wasm32")]
 impl<'a, T> ReusableBoxFuture<'a, T> {
     /// Create a new `ReusableBoxFuture<T>` containing the provided future.
-    pub fn new<F>(future: F) -> Self
+    pub(crate) fn new<F>(future: F) -> Self
     where
         F: Future<Output = T> + 'a,
     {
@@ -95,7 +95,7 @@ impl<'a, T> ReusableBoxFuture<'a, T> {
     ///
     /// This reallocates if and only if the layout of the provided future is
     /// different from the layout of the currently stored future.
-    pub fn set<F>(&mut self, future: F)
+    pub(crate) fn set<F>(&mut self, future: F)
     where
         F: Future<Output = T> + SendOutsideWasm + 'a,
     {
@@ -109,7 +109,7 @@ impl<'a, T> ReusableBoxFuture<'a, T> {
     /// This function never reallocates, but returns an error if the provided
     /// future has a different size or alignment from the currently stored
     /// future.
-    pub fn try_set<F>(&mut self, future: F) -> Result<(), F>
+    pub(crate) fn try_set<F>(&mut self, future: F) -> Result<(), F>
     where
         F: Future<Output = T> + SendOutsideWasm + 'a,
     {
@@ -134,12 +134,12 @@ impl<'a, T> ReusableBoxFuture<'a, T> {
     }
 
     /// Get a pinned reference to the underlying future.
-    pub fn get_pin(&mut self) -> Pin<&mut (dyn Future<Output = T>)> {
+    pub(crate) fn get_pin(&mut self) -> Pin<&mut (dyn Future<Output = T>)> {
         self.boxed.as_mut()
     }
 
     /// Poll the future stored inside this box.
-    pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<T> {
+    pub(crate) fn poll(&mut self, cx: &mut Context<'_>) -> Poll<T> {
         self.get_pin().poll(cx)
     }
 }

--- a/eyeball-im/src/vector/traits.rs
+++ b/eyeball-im/src/vector/traits.rs
@@ -1,0 +1,173 @@
+use std::alloc::Layout;
+use std::future::{self, Future};
+use std::mem::{self, ManuallyDrop};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::{fmt, ptr};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use tokio_util::sync::ReusableBoxFuture;
+struct CallOnDrop<O, F: FnOnce() -> O> {
+    f: ManuallyDrop<F>,
+}
+
+impl<O, F: FnOnce() -> O> CallOnDrop<O, F> {
+    fn new(f: F) -> Self {
+        let f = ManuallyDrop::new(f);
+        Self { f }
+    }
+    fn call(self) -> O {
+        let mut this = ManuallyDrop::new(self);
+        let f = unsafe { ManuallyDrop::take(&mut this.f) };
+        f()
+    }
+}
+
+impl<O, F: FnOnce() -> O> Drop for CallOnDrop<O, F> {
+    fn drop(&mut self) {
+        let f = unsafe { ManuallyDrop::take(&mut self.f) };
+        f();
+    }
+}
+
+fn reuse_pin_box<T: ?Sized, U, O, F>(boxed: Pin<Box<T>>, new_value: U, callback: F) -> Result<O, U>
+where
+    F: FnOnce(Box<U>) -> O,
+{
+    let layout = Layout::for_value::<T>(&*boxed);
+    if layout != Layout::new::<U>() {
+        return Err(new_value);
+    }
+
+    // SAFETY: We don't ever construct a non-pinned reference to the old `T` from now on, and we
+    // always drop the `T`.
+    let raw: *mut T = Box::into_raw(unsafe { Pin::into_inner_unchecked(boxed) });
+
+    // When dropping the old value panics, we still want to call `callback` — so move the rest of
+    // the code into a guard type.
+    let guard = CallOnDrop::new(|| {
+        let raw: *mut U = raw.cast::<U>();
+        unsafe { raw.write(new_value) };
+
+        // SAFETY:
+        // - `T` and `U` have the same layout.
+        // - `raw` comes from a `Box` that uses the same allocator as this one.
+        // - `raw` points to a valid instance of `U` (we just wrote it in).
+        let boxed = unsafe { Box::from_raw(raw) };
+
+        callback(boxed)
+    });
+
+    // Drop the old value.
+    unsafe { ptr::drop_in_place(raw) };
+
+    // Run the rest of the code.
+    Ok(guard.call())
+}
+
+/// A reusable `Pin<Box<dyn Future<Output = T> + Send + 'a>>`.
+///
+/// This type lets you replace the future stored in the box without
+/// reallocating when the size and alignment permits this.
+#[cfg(target_arch = "wasm32")]
+pub struct ReusableBoxFuture<'a, T> {
+    boxed: Pin<Box<dyn Future<Output = T> + 'a>>,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<'a, T> fmt::Debug for ReusableBoxFuture<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReusableBoxFuture").field("boxed", &"Future").finish()
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<'a, T> ReusableBoxFuture<'a, T> {
+    /// Create a new `ReusableBoxFuture<T>` containing the provided future.
+    pub fn new<F>(future: F) -> Self
+    where
+        F: Future<Output = T> + 'a,
+    {
+        Self { boxed: Box::pin(future) }
+    }
+
+    /// Replace the future currently stored in this box.
+    ///
+    /// This reallocates if and only if the layout of the provided future is
+    /// different from the layout of the currently stored future.
+    pub fn set<F>(&mut self, future: F)
+    where
+        F: Future<Output = T> + SendOutsideWasm + 'a,
+    {
+        if let Err(future) = self.try_set(future) {
+            *self = Self::new(future);
+        }
+    }
+
+    /// Replace the future currently stored in this box.
+    ///
+    /// This function never reallocates, but returns an error if the provided
+    /// future has a different size or alignment from the currently stored
+    /// future.
+    pub fn try_set<F>(&mut self, future: F) -> Result<(), F>
+    where
+        F: Future<Output = T> + SendOutsideWasm + 'a,
+    {
+        // If we try to inline the contents of this function, the type checker complains because
+        // the bound `T: 'a` is not satisfied in the call to `pending()`. But by putting it in an
+        // inner function that doesn't have `T` as a generic parameter, we implicitly get the bound
+        // `F::Output: 'a` transitively through `F: 'a`, allowing us to call `pending()`.
+        #[inline(always)]
+        fn real_try_set<'a, F>(
+            this: &mut ReusableBoxFuture<'a, F::Output>,
+            future: F,
+        ) -> Result<(), F>
+        where
+            F: Future + SendOutsideWasm + 'a,
+        {
+            // future::Pending<T> is a ZST so this never allocates.
+            let boxed = mem::replace(&mut this.boxed, Box::pin(future::pending()));
+            reuse_pin_box(boxed, future, |boxed| this.boxed = Pin::from(boxed))
+        }
+
+        real_try_set(self, future)
+    }
+
+    /// Get a pinned reference to the underlying future.
+    pub fn get_pin(&mut self) -> Pin<&mut (dyn Future<Output = T>)> {
+        self.boxed.as_mut()
+    }
+
+    /// Poll the future stored inside this box.
+    pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<T> {
+        self.get_pin().poll(cx)
+    }
+}
+
+/// Alias for `Send` on non-wasm, empty trait (implemented by everything) on
+/// wasm.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait SendOutsideWasm: Send {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Send> SendOutsideWasm for T {}
+
+/// Alias for `Send` on non-wasm, empty trait (implemented by everything) on
+/// wasm.
+#[cfg(target_arch = "wasm32")]
+pub trait SendOutsideWasm {}
+#[cfg(target_arch = "wasm32")]
+impl<T> SendOutsideWasm for T {}
+
+/// Alias for `Sync` on non-wasm, empty trait (implemented by everything) on
+/// wasm.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait SyncOutsideWasm: Sync {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Sync> SyncOutsideWasm for T {}
+
+/// Alias for `Sync` on non-wasm, empty trait (implemented by everything) on
+/// wasm.
+#[cfg(target_arch = "wasm32")]
+pub trait SyncOutsideWasm {}
+#[cfg(target_arch = "wasm32")]
+impl<T> SyncOutsideWasm for T {}

--- a/eyeball-im/src/vector/transaction.rs
+++ b/eyeball-im/src/vector/transaction.rs
@@ -2,7 +2,10 @@ use std::{fmt, mem, ops};
 
 use imbl::Vector;
 
-use crate::vector::OneOrManyDiffs;
+use crate::vector::{
+    traits::{SendOutsideWasm, SyncOutsideWasm},
+    OneOrManyDiffs,
+};
 
 use super::{entry::EntryIndex, BroadcastMessage, ObservableVector, VectorDiff};
 
@@ -21,7 +24,9 @@ pub struct ObservableVectorTransaction<'o, T: Clone> {
     batch: Vec<VectorDiff<T>>,
 }
 
-impl<'o, T: Clone + Send + Sync + 'static> ObservableVectorTransaction<'o, T> {
+impl<'o, T: Clone + SendOutsideWasm + SyncOutsideWasm + 'static>
+    ObservableVectorTransaction<'o, T>
+{
     pub(super) fn new(inner: &'o mut ObservableVector<T>) -> Self {
         let values = inner.values.clone();
         Self { inner, values, batch: Vec::new() }
@@ -316,7 +321,7 @@ pub struct ObservableVectorTransactionEntry<'a, 'o, T: Clone> {
 
 impl<'a, 'o, T> ObservableVectorTransactionEntry<'a, 'o, T>
 where
-    T: Clone + Send + Sync + 'static,
+    T: Clone + SendOutsideWasm + SyncOutsideWasm + 'static,
 {
     pub(super) fn new(inner: &'a mut ObservableVectorTransaction<'o, T>, index: usize) -> Self {
         Self { inner, index: EntryIndex::Owned(index) }
@@ -397,7 +402,7 @@ pub struct ObservableVectorTransactionEntries<'a, 'o, T: Clone> {
 
 impl<'a, 'o, T> ObservableVectorTransactionEntries<'a, 'o, T>
 where
-    T: Clone + Send + Sync + 'static,
+    T: Clone + SendOutsideWasm + SyncOutsideWasm + 'static,
 {
     pub(super) fn new(inner: &'a mut ObservableVectorTransaction<'o, T>) -> Self {
         Self { inner, index: 0 }

--- a/eyeball/src/subscriber/async_lock.rs
+++ b/eyeball/src/subscriber/async_lock.rs
@@ -17,7 +17,7 @@ pub struct AsyncSubscriberState<T> {
     get_lock: ReusableBoxFuture<'static, OwnedSharedReadGuard<ObservableState<T>>>,
 }
 
-impl<S: Send + Sync + 'static> Clone for AsyncSubscriberState<S> {
+impl<S: SendOutsideWasm + SyncOutsideWasm + 'static> Clone for AsyncSubscriberState<S> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -32,7 +32,7 @@ impl<S: fmt::Debug> fmt::Debug for AsyncSubscriberState<S> {
     }
 }
 
-impl<T: Send + Sync + 'static> Subscriber<T, AsyncLock> {
+impl<T: SendOutsideWasm + SyncOutsideWasm + 'static> Subscriber<T, AsyncLock> {
     pub(crate) fn new_async(inner: SharedReadLock<ObservableState<T>>, version: u64) -> Self {
         let get_lock = ReusableBoxFuture::new(inner.clone().lock_owned());
         Self { state: AsyncSubscriberState { inner, get_lock }, observed_version: version }
@@ -147,7 +147,7 @@ impl<T: Send + Sync + 'static> Subscriber<T, AsyncLock> {
     }
 }
 
-impl<T: Clone + Send + Sync + 'static> Stream for Subscriber<T, AsyncLock> {
+impl<T: Clone + SendOutsideWasm + SyncOutsideWasm + 'static> Stream for Subscriber<T, AsyncLock> {
     type Item = T;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -155,7 +155,7 @@ impl<T: Clone + Send + Sync + 'static> Stream for Subscriber<T, AsyncLock> {
     }
 }
 
-impl<T: Clone + Send + Sync + 'static> Future for Next<'_, T, AsyncLock> {
+impl<T: Clone + SendOutsideWasm + SyncOutsideWasm + 'static> Future for Next<'_, T, AsyncLock> {
     type Output = Option<T>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {


### PR DESCRIPTION
I wanted to explore what removing the +Send+Sync requirements would look like for wasm32 architectures.

With this change, I'm able to build the matrix-sdk-ui crate locally for wasm32-unknown-unknown, while still being able to compile the existing wasm32 targets.

The one part I'm not totally sure about is the `ReusableBoxFuture` polyfill, it feels like there should be a better way to achieve that than what I've done here.