### PR TITLE
chore: Rename `LimitBuf` and `SortBuf`

### DIFF
--- a/eyeball-im-util/src/vector.rs
+++ b/eyeball-im-util/src/vector.rs
@@ -41,11 +41,11 @@ type VectorDiffContainerStreamFamily<S> =
 type VectorDiffContainerDiff<S> = VectorDiff<VectorDiffContainerStreamElement<S>>;
 
 /// Type alias for extracting the buffer type from a stream of
-/// [`VectorDiffContainer`]s' `LimitBuf`.
-type VectorDiffContainerStreamLimitBuf<S> =
-    <<S as Stream>::Item as VectorDiffContainerOps<VectorDiffContainerStreamElement<S>>>::LimitBuf;
+/// [`VectorDiffContainer`]s' `ArrayBuf`.
+type VectorDiffContainerStreamArrayBuf<S> =
+    <<S as Stream>::Item as VectorDiffContainerOps<VectorDiffContainerStreamElement<S>>>::ArrayBuf;
 
 /// Type alias for extracting the buffer type from a stream of
-/// [`VectorDiffContainer`]s' `SortBuf`.
-type VectorDiffContainerStreamSortBuf<S> =
-    <<S as Stream>::Item as VectorDiffContainerOps<VectorDiffContainerStreamElement<S>>>::SortBuf;
+/// [`VectorDiffContainer`]s' `VecBuf`.
+type VectorDiffContainerStreamVecBuf<S> =
+    <<S as Stream>::Item as VectorDiffContainerOps<VectorDiffContainerStreamElement<S>>>::VecBuf;

--- a/eyeball-im-util/src/vector/limit.rs
+++ b/eyeball-im-util/src/vector/limit.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use super::{
-    VectorDiffContainer, VectorDiffContainerOps, VectorDiffContainerStreamElement,
-    VectorDiffContainerStreamLimitBuf, VectorObserver,
+    VectorDiffContainer, VectorDiffContainerOps, VectorDiffContainerStreamArrayBuf,
+    VectorDiffContainerStreamElement, VectorObserver,
 };
 use eyeball_im::VectorDiff;
 use futures_core::Stream;
@@ -63,7 +63,7 @@ pin_project! {
         // with a limit of 2 on top: if an item is popped at the front then 10
         // is removed, but 12 has to be pushed back as it "enters" the "view".
         // That second `PushBack` diff is buffered here.
-        ready_values: VectorDiffContainerStreamLimitBuf<S>,
+        ready_values: VectorDiffContainerStreamArrayBuf<S>,
     }
 }
 
@@ -176,7 +176,7 @@ where
     fn poll_next(&mut self, cx: &mut task::Context<'_>) -> Poll<Option<S::Item>> {
         loop {
             // First off, if any values are ready, return them.
-            if let Some(value) = S::Item::pop_from_limit_buf(self.ready_values) {
+            if let Some(value) = S::Item::pop_from_array_buf(self.ready_values) {
                 return Poll::Ready(Some(value));
             }
 
@@ -197,7 +197,7 @@ where
             };
 
             // Consume and apply the diffs if possible.
-            let ready = diffs.push_into_limit_buf(self.ready_values, |diff| {
+            let ready = diffs.push_into_array_buf(self.ready_values, |diff| {
                 let limit = *self.limit;
                 let prev_len = self.buffered_vector.len();
 

--- a/eyeball-im-util/src/vector/limit.rs
+++ b/eyeball-im-util/src/vector/limit.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use super::{
-    VectorDiffContainer, VectorDiffContainerOps, VectorDiffContainerStreamArrayBuf,
+    ops::BUF_CAP, VectorDiffContainer, VectorDiffContainerOps, VectorDiffContainerStreamArrayBuf,
     VectorDiffContainerStreamElement, VectorObserver,
 };
 use eyeball_im::VectorDiff;
@@ -319,7 +319,7 @@ fn handle_diff<T: Clone>(
     limit: usize,
     prev_len: usize,
     buffered_vector: &Vector<T>,
-) -> ArrayVec<VectorDiff<T>, 2> {
+) -> ArrayVec<VectorDiff<T>, BUF_CAP> {
     // If the limit is zero, we have nothing to do.
     if limit == 0 {
         return ArrayVec::new();

--- a/eyeball-im-util/src/vector/ops.rs
+++ b/eyeball-im-util/src/vector/ops.rs
@@ -2,6 +2,12 @@ use arrayvec::ArrayVec;
 use eyeball_im::VectorDiff;
 use smallvec::SmallVec;
 
+/// Default capacity for the `VectorDiffContainerOps::ArrayBuf` buffer or the
+/// `VectorDiffContainerOps::VecBuf` buffer.
+///
+/// Capacity is hardcoded to 2 because that's all we need for now.
+pub(super) const BUF_CAP: usize = 2;
+
 pub trait VectorDiffContainerOps<T>: Sized {
     type Family: VectorDiffContainerFamily;
     type ArrayBuf: Default;
@@ -17,7 +23,7 @@ pub trait VectorDiffContainerOps<T>: Sized {
     fn push_into_array_buf(
         self,
         buffer: &mut Self::ArrayBuf,
-        make_diffs: impl FnMut(VectorDiff<T>) -> ArrayVec<VectorDiff<T>, 2>,
+        make_diffs: impl FnMut(VectorDiff<T>) -> ArrayVec<VectorDiff<T>, BUF_CAP>,
     ) -> Option<Self>;
 
     fn pop_from_array_buf(buffer: &mut Self::ArrayBuf) -> Option<Self>;
@@ -25,7 +31,7 @@ pub trait VectorDiffContainerOps<T>: Sized {
     fn push_into_vec_buf(
         self,
         buffer: &mut Self::VecBuf,
-        make_diffs: impl FnMut(VectorDiff<T>) -> SmallVec<[VectorDiff<T>; 2]>,
+        make_diffs: impl FnMut(VectorDiff<T>) -> SmallVec<[VectorDiff<T>; BUF_CAP]>,
     ) -> Option<Self>;
 
     fn pop_from_vec_buf(buffer: &mut Self::VecBuf) -> Option<Self>;
@@ -37,7 +43,7 @@ pub type VectorDiffContainerFamilyMember<F, U> = <F as VectorDiffContainerFamily
 impl<T> VectorDiffContainerOps<T> for VectorDiff<T> {
     type Family = VectorDiffFamily;
     type ArrayBuf = Option<VectorDiff<T>>;
-    type VecBuf = SmallVec<[VectorDiff<T>; 2]>;
+    type VecBuf = SmallVec<[VectorDiff<T>; BUF_CAP]>;
 
     fn from_item(vector_diff: VectorDiff<T>) -> Self {
         vector_diff
@@ -53,7 +59,7 @@ impl<T> VectorDiffContainerOps<T> for VectorDiff<T> {
     fn push_into_array_buf(
         self,
         buffer: &mut Self::ArrayBuf,
-        mut make_diffs: impl FnMut(VectorDiff<T>) -> ArrayVec<VectorDiff<T>, 2>,
+        mut make_diffs: impl FnMut(VectorDiff<T>) -> ArrayVec<VectorDiff<T>, BUF_CAP>,
     ) -> Option<Self> {
         assert!(buffer.is_none(), "buffer must be None when calling push_into_array_buf");
 
@@ -75,7 +81,7 @@ impl<T> VectorDiffContainerOps<T> for VectorDiff<T> {
     fn push_into_vec_buf(
         self,
         buffer: &mut Self::VecBuf,
-        mut make_diffs: impl FnMut(VectorDiff<T>) -> SmallVec<[VectorDiff<T>; 2]>,
+        mut make_diffs: impl FnMut(VectorDiff<T>) -> SmallVec<[VectorDiff<T>; BUF_CAP]>,
     ) -> Option<Self> {
         assert!(buffer.is_empty(), "buffer must be empty when calling `push_into_vec_buf`");
 
@@ -125,7 +131,7 @@ impl<T> VectorDiffContainerOps<T> for Vec<VectorDiff<T>> {
     fn push_into_array_buf(
         self,
         _buffer: &mut Self::ArrayBuf,
-        make_diffs: impl FnMut(VectorDiff<T>) -> ArrayVec<VectorDiff<T>, 2>,
+        make_diffs: impl FnMut(VectorDiff<T>) -> ArrayVec<VectorDiff<T>, BUF_CAP>,
     ) -> Option<Self> {
         let res: Vec<_> = self.into_iter().flat_map(make_diffs).collect();
 
@@ -143,7 +149,7 @@ impl<T> VectorDiffContainerOps<T> for Vec<VectorDiff<T>> {
     fn push_into_vec_buf(
         self,
         _buffer: &mut (),
-        make_diffs: impl FnMut(VectorDiff<T>) -> SmallVec<[VectorDiff<T>; 2]>,
+        make_diffs: impl FnMut(VectorDiff<T>) -> SmallVec<[VectorDiff<T>; BUF_CAP]>,
     ) -> Option<Self> {
         let res: Vec<_> = self.into_iter().flat_map(make_diffs).collect();
 

--- a/eyeball-im-util/src/vector/sort.rs
+++ b/eyeball-im-util/src/vector/sort.rs
@@ -12,7 +12,7 @@ use smallvec::SmallVec;
 
 use super::{
     VectorDiffContainer, VectorDiffContainerOps, VectorDiffContainerStreamElement,
-    VectorDiffContainerStreamSortBuf,
+    VectorDiffContainerStreamVecBuf,
 };
 
 type UnsortedIndex = usize;
@@ -237,7 +237,7 @@ pin_project! {
         // Thus, if the item type is just `VectorDiff<_>` (non-bached, can't
         // just add diffs to a `poll_next` result), we need a buffer to store the
         // possible extra items in.
-        ready_values: VectorDiffContainerStreamSortBuf<S>,
+        ready_values: VectorDiffContainerStreamVecBuf<S>,
     }
 }
 
@@ -286,7 +286,7 @@ where
 
         loop {
             // First off, if any values are ready, return them.
-            if let Some(value) = S::Item::pop_from_sort_buf(this.ready_values) {
+            if let Some(value) = S::Item::pop_from_vec_buf(this.ready_values) {
                 return Poll::Ready(Some(value));
             }
 
@@ -296,7 +296,7 @@ where
             };
 
             // Consume and apply the diffs if possible.
-            let ready = diffs.push_into_sort_buf(this.ready_values, |diff| {
+            let ready = diffs.push_into_vec_buf(this.ready_values, |diff| {
                 handle_diff_and_update_buffered_vector(diff, compare, this.buffered_vector)
             });
 

--- a/eyeball-im-util/src/vector/sort.rs
+++ b/eyeball-im-util/src/vector/sort.rs
@@ -11,7 +11,7 @@ use pin_project_lite::pin_project;
 use smallvec::SmallVec;
 
 use super::{
-    VectorDiffContainer, VectorDiffContainerOps, VectorDiffContainerStreamElement,
+    ops::BUF_CAP, VectorDiffContainer, VectorDiffContainerOps, VectorDiffContainerStreamElement,
     VectorDiffContainerStreamVecBuf,
 };
 
@@ -320,7 +320,7 @@ fn handle_diff_and_update_buffered_vector<T, F>(
     diff: VectorDiff<T>,
     compare: F,
     buffered_vector: &mut Vector<(usize, T)>,
-) -> SmallVec<[VectorDiff<T>; 2]>
+) -> SmallVec<[VectorDiff<T>; BUF_CAP]>
 where
     T: Clone,
     F: Fn(&T, &T) -> Ordering,


### PR DESCRIPTION
This patch renames `LimitBuf` to `ArrayBuf` and `SortBuf` to `VecBuf`.
The idea is to identify these buffers by their intrinsic properties
(an array and a vector) instead of by their usages (inside `Limit` or
`Sort`). It makes reusability easier for new types.

Another patch adds the `BUF_CAP` constant to represent buffer
capacities.