### PR TITLE
feat: Add the `Tail` higher-order stream

### DIFF
--- a/eyeball-im-util/CHANGELOG.md
+++ b/eyeball-im-util/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add the `Tail` adapter
+- Improve the documentation of `Head` by adding an example
 - Rename `Limit` to `Head`, along with all the similar methods, like
   `VectorObserverExt::limit` which becomes `VectorObserverExt::head` and so on.
 

--- a/eyeball-im-util/src/vector.rs
+++ b/eyeball-im-util/src/vector.rs
@@ -4,6 +4,7 @@ mod filter;
 mod head;
 mod ops;
 mod sort;
+mod tail;
 mod traits;
 
 use eyeball_im::VectorDiff;
@@ -14,6 +15,7 @@ pub use self::{
     filter::{Filter, FilterMap},
     head::{EmptyLimitStream, Head},
     sort::{Sort, SortBy, SortByKey},
+    tail::Tail,
     traits::{
         BatchedVectorSubscriber, VectorDiffContainer, VectorObserver, VectorObserverExt,
         VectorSubscriberExt,
@@ -44,6 +46,11 @@ type VectorDiffContainerDiff<S> = VectorDiff<VectorDiffContainerStreamElement<S>
 /// [`VectorDiffContainer`]s' `HeadBuf`.
 type VectorDiffContainerStreamHeadBuf<S> =
     <<S as Stream>::Item as VectorDiffContainerOps<VectorDiffContainerStreamElement<S>>>::HeadBuf;
+
+/// Type alias for extracting the buffer type from a stream of
+/// [`VectorDiffContainer`]s' `TailBuf`.
+type VectorDiffContainerStreamTailBuf<S> =
+    <<S as Stream>::Item as VectorDiffContainerOps<VectorDiffContainerStreamElement<S>>>::TailBuf;
 
 /// Type alias for extracting the buffer type from a stream of
 /// [`VectorDiffContainer`]s' `SortBuf`.

--- a/eyeball-im-util/src/vector/head.rs
+++ b/eyeball-im-util/src/vector/head.rs
@@ -18,6 +18,8 @@ use pin_project_lite::pin_project;
 pin_project! {
     /// A [`VectorDiff`] stream adapter that presents a limited view of the
     /// underlying [`ObservableVector`]'s items. The view starts from index 0.
+    /// This is the opposite of [`Tail`](super::Tail), which starts from the
+    /// end.
     ///
     /// For example, let `S` be a `Stream<Item = VectorDiff>`. The [`Vector`]
     /// represented by `S` can have any length, but one may want to virtually
@@ -31,6 +33,50 @@ pin_project! {
     ///
     /// It's okay to have a limit larger than the length of the observed
     /// `Vector`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use eyeball_im::{ObservableVector, VectorDiff};
+    /// use eyeball_im_util::vector::VectorObserverExt;
+    /// use imbl::vector;
+    /// use stream_assert::{assert_closed, assert_next_eq, assert_pending};
+    ///
+    /// // Our vector.
+    /// let mut ob = ObservableVector::<char>::new();
+    /// let (values, mut sub) = ob.subscribe().head(3);
+    ///
+    /// assert!(values.is_empty());
+    /// assert_pending!(sub);
+    ///
+    /// // Append multiple values.
+    /// ob.append(vector!['a', 'b', 'c', 'd']);
+    /// // We get a `VectorDiff::Append` with the first 3 values!
+    /// assert_next_eq!(sub, VectorDiff::Append { values: vector!['a', 'b', 'c'] });
+    ///
+    /// // Let's recap what we have. `ob` is our `ObservableVector`,
+    /// // `sub` is the “limited view” of `ob`:
+    /// // | `ob`  | a b c d |
+    /// // | `sub` | a b c   |
+    ///
+    /// // Front push a value.
+    /// ob.push_front('e');
+    /// // We get three `VectorDiff`s!
+    /// assert_next_eq!(sub, VectorDiff::PopBack);
+    /// assert_next_eq!(sub, VectorDiff::PushFront { value: 'e' });
+    ///
+    /// // Let's recap what we have:
+    /// // | `ob`  | e a b c d |
+    /// // | `sub` | e a b     |
+    /// //           ^     ^
+    /// //           |     |
+    /// //           |     removed with `VectorDiff::PopBack`
+    /// //           added with `VectorDiff::PushFront`
+    ///
+    /// assert_pending!(sub);
+    /// drop(ob);
+    /// assert_closed!(sub);
+    /// ```
     ///
     /// [`ObservableVector`]: eyeball_im::ObservableVector
     #[project = HeadProj]

--- a/eyeball-im-util/src/vector/head.rs
+++ b/eyeball-im-util/src/vector/head.rs
@@ -17,7 +17,7 @@ use pin_project_lite::pin_project;
 
 pin_project! {
     /// A [`VectorDiff`] stream adapter that presents a limited view of the
-    /// underlying [`ObservableVector`]s items. The view starts from index 0.
+    /// underlying [`ObservableVector`]'s items. The view starts from index 0.
     ///
     /// For example, let `S` be a `Stream<Item = VectorDiff>`. The [`Vector`]
     /// represented by `S` can have any length, but one may want to virtually

--- a/eyeball-im-util/src/vector/ops.rs
+++ b/eyeball-im-util/src/vector/ops.rs
@@ -5,6 +5,7 @@ use smallvec::SmallVec;
 pub trait VectorDiffContainerOps<T>: Sized {
     type Family: VectorDiffContainerFamily;
     type HeadBuf: Default;
+    type TailBuf: Default;
     type SortBuf: Default;
 
     fn from_item(vector_diff: VectorDiff<T>) -> Self;
@@ -22,6 +23,16 @@ pub trait VectorDiffContainerOps<T>: Sized {
 
     fn pop_from_head_buf(buffer: &mut Self::HeadBuf) -> Option<Self>;
 
+    fn push_into_tail_buf(
+        self,
+        buffer: &mut Self::TailBuf,
+        map_diffs: impl FnMut(VectorDiff<T>) -> SmallVec<[VectorDiff<T>; 2]>,
+    ) -> Option<Self>;
+
+    fn extend_tail_buf(diffs: Vec<VectorDiff<T>>, buffer: &mut Self::TailBuf) -> Option<Self>;
+
+    fn pop_from_tail_buf(buffer: &mut Self::TailBuf) -> Option<Self>;
+
     fn push_into_sort_buf(
         self,
         buffer: &mut Self::SortBuf,
@@ -37,6 +48,7 @@ pub type VectorDiffContainerFamilyMember<F, U> = <F as VectorDiffContainerFamily
 impl<T> VectorDiffContainerOps<T> for VectorDiff<T> {
     type Family = VectorDiffFamily;
     type HeadBuf = Option<VectorDiff<T>>;
+    type TailBuf = SmallVec<[VectorDiff<T>; 2]>;
     type SortBuf = SmallVec<[VectorDiff<T>; 2]>;
 
     fn from_item(vector_diff: VectorDiff<T>) -> Self {
@@ -72,6 +84,28 @@ impl<T> VectorDiffContainerOps<T> for VectorDiff<T> {
         buffer.take()
     }
 
+    fn push_into_tail_buf(
+        self,
+        buffer: &mut Self::TailBuf,
+        mut map_diffs: impl FnMut(VectorDiff<T>) -> SmallVec<[VectorDiff<T>; 2]>,
+    ) -> Option<Self> {
+        buffer.insert_many(0, map_diffs(self).into_iter().rev());
+
+        buffer.pop()
+    }
+
+    fn extend_tail_buf(diffs: Vec<VectorDiff<T>>, buffer: &mut Self::TailBuf) -> Option<Self> {
+        // We cannot pop front on a `SmallVec`. We store all `diffs` in reverse order to
+        // pop from it.
+        buffer.insert_many(0, diffs.into_iter().rev());
+
+        buffer.pop()
+    }
+
+    fn pop_from_tail_buf(buffer: &mut Self::TailBuf) -> Option<Self> {
+        buffer.pop()
+    }
+
     fn push_into_sort_buf(
         self,
         buffer: &mut Self::SortBuf,
@@ -103,6 +137,7 @@ impl<T> VectorDiffContainerOps<T> for VectorDiff<T> {
 impl<T> VectorDiffContainerOps<T> for Vec<VectorDiff<T>> {
     type Family = VecVectorDiffFamily;
     type HeadBuf = ();
+    type TailBuf = ();
     type SortBuf = ();
 
     fn from_item(vector_diff: VectorDiff<T>) -> Self {
@@ -137,6 +172,32 @@ impl<T> VectorDiffContainerOps<T> for Vec<VectorDiff<T>> {
     }
 
     fn pop_from_head_buf(_: &mut Self::HeadBuf) -> Option<Self> {
+        None
+    }
+
+    fn push_into_tail_buf(
+        self,
+        _buffer: &mut Self::TailBuf,
+        map_diffs: impl FnMut(VectorDiff<T>) -> SmallVec<[VectorDiff<T>; 2]>,
+    ) -> Option<Self> {
+        let res: Vec<_> = self.into_iter().flat_map(map_diffs).collect();
+
+        if res.is_empty() {
+            None
+        } else {
+            Some(res)
+        }
+    }
+
+    fn extend_tail_buf(diffs: Vec<VectorDiff<T>>, _buffer: &mut Self::TailBuf) -> Option<Self> {
+        if diffs.is_empty() {
+            None
+        } else {
+            Some(diffs)
+        }
+    }
+
+    fn pop_from_tail_buf(_buffer: &mut Self::TailBuf) -> Option<Self> {
         None
     }
 

--- a/eyeball-im-util/src/vector/tail.rs
+++ b/eyeball-im-util/src/vector/tail.rs
@@ -103,12 +103,12 @@ pin_project! {
         // The current limit.
         limit: usize,
 
-        // This adapter is not a basic filter: It can produce up to two items
+        // This adapter is not a basic filter: It can produce multiple items
         // per item of the underlying stream.
         //
         // Thus, if the item type is just `VectorDiff<_>` (non-bached, can't
-        // just add diffs to a poll_next result), we need a buffer to store the
-        // possible extra item in. For example if the vector is [10, 11, 12]
+        // just add diffs to a `poll_next` result), we need a buffer to store
+        // the possible extra item in. For example if the vector is [10, 11, 12]
         // with a limit of 2 on top: if an item is popped at the back then 12
         // is removed, but 10 has to be pushed front as it "enters" the "view".
         // That second `PushFront` diff is buffered here.

--- a/eyeball-im-util/src/vector/tail.rs
+++ b/eyeball-im-util/src/vector/tail.rs
@@ -1,0 +1,540 @@
+use smallvec::SmallVec;
+use std::{
+    cmp::{min, Ordering},
+    iter::repeat,
+    mem,
+    pin::Pin,
+    task::{self, ready, Poll},
+};
+
+use super::{
+    EmptyLimitStream, VectorDiffContainer, VectorDiffContainerOps,
+    VectorDiffContainerStreamElement, VectorDiffContainerStreamTailBuf, VectorObserver,
+};
+use eyeball_im::VectorDiff;
+use futures_core::Stream;
+use imbl::Vector;
+use pin_project_lite::pin_project;
+
+pin_project! {
+    /// A [`VectorDiff`] stream adapter that presents a _reversed_ limited view
+    /// of the underlying [`ObservableVector`]s items. The view starts from the
+    /// last index of the `ObservableVector`, i.e. it starts from the end. This
+    /// is the opposite of [`Head`](super::Head), which starts from 0.
+    ///
+    /// For example, let `S` be a `Stream<Item = VectorDiff>`. The [`Vector`]
+    /// represented by `S` can have any length, but one may want to virtually
+    /// _limit_ this `Vector` from the end to a certain size. Then this `Tail`
+    /// adapter is appropriate.
+    ///
+    /// An internal buffered vector is kept so that the adapter knows which
+    /// values can be added when the limit is increased, or when values are
+    /// removed and new values must be inserted. This fact is important if the
+    /// items of the `Vector` have a non-negligible size.
+    ///
+    /// It's okay to have a limit larger than the length of the observed
+    /// `Vector`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use eyeball_im::{ObservableVector, VectorDiff};
+    /// use eyeball_im_util::vector::VectorObserverExt;
+    /// use imbl::vector;
+    /// use stream_assert::{assert_closed, assert_next_eq, assert_pending};
+    ///
+    /// // Our vector.
+    /// let mut ob = ObservableVector::<char>::new();
+    /// let (values, mut sub) = ob.subscribe().tail(3);
+    ///
+    /// assert!(values.is_empty());
+    /// assert_pending!(sub);
+    ///
+    /// // Append multiple values.
+    /// ob.append(vector!['a', 'b', 'c', 'd']);
+    /// // We get a `VectorDiff::Append` with the latest 3 values!
+    /// assert_next_eq!(sub, VectorDiff::Append { values: vector!['b', 'c', 'd'] });
+    ///
+    /// // Let's recap what we have. `ob` is our `ObservableVector`,
+    /// // `sub` is the “limited view” of `ob`:
+    /// // | `ob`  | a b c d |
+    /// // | `sub` |   b c d |
+    ///
+    /// // Append multiple other values.
+    /// ob.append(vector!['e', 'f']);
+    /// // We get three `VectorDiff`s!
+    /// assert_next_eq!(sub, VectorDiff::PopFront);
+    /// assert_next_eq!(sub, VectorDiff::PopFront);
+    /// assert_next_eq!(sub, VectorDiff::Append { values: vector!['e', 'f'] });
+    ///
+    /// // Let's recap what we have:
+    /// // | `ob`  | a b c d e f |
+    /// // | `sub` |       d e f |
+    /// //             ^ ^   ^^^
+    /// //             | |   |
+    /// //             | |   added with `VectorDiff::Append { .. }`
+    /// //             | removed with `VectorDiff::PopFront`
+    /// //             removed with `VectorDiff::PopFront`
+    ///
+    /// assert_pending!(sub);
+    /// drop(ob);
+    /// assert_closed!(sub);
+    /// ```
+    ///
+    /// [`ObservableVector`]: eyeball_im::ObservableVector
+    #[project = TailProj]
+    pub struct Tail<S, L>
+    where
+        S: Stream,
+        S::Item: VectorDiffContainer,
+    {
+        // The main stream to poll items from.
+        #[pin]
+        inner_stream: S,
+
+        // The limit stream to poll new limits from.
+        #[pin]
+        limit_stream: L,
+
+        // The buffered vector that is updated with the main stream's items.
+        // It's used to provide missing items, e.g. when the limit increases.
+        buffered_vector: Vector<VectorDiffContainerStreamElement<S>>,
+
+        // The current limit.
+        limit: usize,
+
+        // This adapter is not a basic filter: It can produce up to two items
+        // per item of the underlying stream.
+        //
+        // Thus, if the item type is just `VectorDiff<_>` (non-bached, can't
+        // just add diffs to a poll_next result), we need a buffer to store the
+        // possible extra item in. For example if the vector is [10, 11, 12]
+        // with a limit of 2 on top: if an item is popped at the back then 12
+        // is removed, but 10 has to be pushed front as it "enters" the "view".
+        // That second `PushFront` diff is buffered here.
+        ready_values: VectorDiffContainerStreamTailBuf<S>,
+    }
+}
+
+impl<S> Tail<S, EmptyLimitStream>
+where
+    S: Stream,
+    S::Item: VectorDiffContainer,
+{
+    /// Create a new [`Tail`] with the given (unlimited) initial values,
+    /// stream of `VectorDiff` updates for those values, and a fixed limit.
+    ///
+    /// Returns the truncated initial values as well as a stream of updates that
+    /// ensure that the resulting vector never exceeds the given limit.
+    pub fn new(
+        initial_values: Vector<VectorDiffContainerStreamElement<S>>,
+        inner_stream: S,
+        limit: usize,
+    ) -> (Vector<VectorDiffContainerStreamElement<S>>, Self) {
+        Self::dynamic_with_initial_limit(initial_values, inner_stream, limit, EmptyLimitStream)
+    }
+}
+
+impl<S, L> Tail<S, L>
+where
+    S: Stream,
+    S::Item: VectorDiffContainer,
+    L: Stream<Item = usize>,
+{
+    /// Create a new [`Tail`] with the given (unlimited) initial values,
+    /// stream of `VectorDiff` updates for those values, and a stream of
+    /// limits.
+    ///
+    /// This is equivalent to `dynamic_with_initial_limit` where the
+    /// `initial_limit` is 0, except that it doesn't return the limited
+    /// vector as it would be empty anyways.
+    ///
+    /// Note that the returned `Tail` won't produce anything until the first
+    /// limit is produced by the limit stream.
+    pub fn dynamic(
+        initial_values: Vector<VectorDiffContainerStreamElement<S>>,
+        inner_stream: S,
+        limit_stream: L,
+    ) -> Self {
+        Self {
+            inner_stream,
+            limit_stream,
+            buffered_vector: initial_values,
+            limit: 0,
+            ready_values: Default::default(),
+        }
+    }
+
+    /// Create a new [`Tail`] with the given (unlimited) initial values,
+    /// stream of `VectorDiff` updates for those values, and an initial
+    /// limit as well as a stream of new limits.
+    pub fn dynamic_with_initial_limit(
+        initial_values: Vector<VectorDiffContainerStreamElement<S>>,
+        inner_stream: S,
+        initial_limit: usize,
+        limit_stream: L,
+    ) -> (Vector<VectorDiffContainerStreamElement<S>>, Self) {
+        let buffered_vector = initial_values.clone();
+
+        let initial_values = if initial_limit < initial_values.len() {
+            initial_values.truncate_from_end(initial_limit)
+        } else {
+            initial_values
+        };
+
+        let stream = Self {
+            inner_stream,
+            limit_stream,
+            buffered_vector,
+            limit: initial_limit,
+            ready_values: Default::default(),
+        };
+
+        (initial_values, stream)
+    }
+}
+
+impl<S, L> Stream for Tail<S, L>
+where
+    S: Stream,
+    S::Item: VectorDiffContainer,
+    L: Stream<Item = usize>,
+{
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project().poll_next(cx)
+    }
+}
+
+impl<S, L> VectorObserver<VectorDiffContainerStreamElement<S>> for Tail<S, L>
+where
+    S: Stream,
+    S::Item: VectorDiffContainer,
+    L: Stream<Item = usize>,
+{
+    type Stream = Self;
+
+    fn into_parts(self) -> (Vector<VectorDiffContainerStreamElement<S>>, Self::Stream) {
+        (self.buffered_vector.clone(), self)
+    }
+}
+
+impl<S, L> TailProj<'_, S, L>
+where
+    S: Stream,
+    S::Item: VectorDiffContainer,
+    L: Stream<Item = usize>,
+{
+    fn poll_next(&mut self, cx: &mut task::Context<'_>) -> Poll<Option<S::Item>> {
+        loop {
+            // First off, if any values are ready, return them.
+            if let Some(value) = S::Item::pop_from_tail_buf(self.ready_values) {
+                return Poll::Ready(Some(value));
+            }
+
+            // Poll a new limit from `limit_stream` before polling `inner_stream`.
+            while let Poll::Ready(Some(next_limit)) = self.limit_stream.as_mut().poll_next(cx) {
+                // Update the limit and emit `VectorDiff`s accordingly.
+                if let Some(diffs) = self.update_limit(next_limit) {
+                    return Poll::Ready(S::Item::extend_tail_buf(diffs, self.ready_values));
+                }
+
+                // If `update_limit` returned `None`, poll the limit stream
+                // again.
+            }
+
+            // Poll `VectorDiff`s from the `inner_stream`.
+            let Some(diffs) = ready!(self.inner_stream.as_mut().poll_next(cx)) else {
+                return Poll::Ready(None);
+            };
+
+            // Consume and apply the diffs if possible.
+            let ready = diffs.push_into_tail_buf(self.ready_values, |diff| {
+                let limit = *self.limit;
+                let prev_len = self.buffered_vector.len();
+
+                // Update the `buffered_vector`. It's a replica of the original observed
+                // `Vector`. We need to maintain it in order to be able to produce valid
+                // `VectorDiff`s when items are missing.
+                diff.clone().apply(self.buffered_vector);
+
+                // Handle the `diff`.
+                handle_diff(diff, limit, prev_len, self.buffered_vector)
+            });
+
+            if let Some(diff) = ready {
+                return Poll::Ready(Some(diff));
+            }
+
+            // Else loop and poll the streams again.
+        }
+    }
+
+    /// Update the limit if necessary.
+    ///
+    /// * If the buffered vector is empty, it returns `None`.
+    /// * If the limit increases, `VectorDiff::PushFront`s or a
+    ///   `VectorDiff::Append` are produced if any items exist.
+    /// * If the limit decreases below the length of the vector,
+    ///   `VectorDiff::PopFront`s are produced.
+    ///
+    /// It's OK to have a `new_limit` larger than the length of the `Vector`.
+    /// The `new_limit` won't be capped.
+    fn update_limit(
+        &mut self,
+        new_limit: usize,
+    ) -> Option<Vec<VectorDiff<VectorDiffContainerStreamElement<S>>>> {
+        // Let's update the limit.
+        let old_limit = mem::replace(self.limit, new_limit);
+
+        if self.buffered_vector.is_empty() {
+            // If empty, nothing to do.
+            return None;
+        }
+
+        match old_limit.cmp(&new_limit) {
+            // old < new
+            Ordering::Less => {
+                let mut missing_items = self
+                    .buffered_vector
+                    .iter()
+                    .rev()
+                    .skip(old_limit)
+                    .take(new_limit - old_limit)
+                    .cloned()
+                    .peekable();
+
+                if missing_items.peek().is_none() {
+                    None
+                } else {
+                    // Let's add the missing items.
+                    //
+                    // Optimisations:
+                    // - if `old_limit` is 0, we can emit a `VectorDiff::Append` to append all
+                    //   missing values,
+                    // - otherwise, we emit a bunch of `VectorDiff::PushFront` in reverse order.
+                    if old_limit == 0 {
+                        Some(vec![VectorDiff::Append { values: missing_items.rev().collect() }])
+                    } else {
+                        Some(
+                            missing_items
+                                .map(|missing_item| VectorDiff::PushFront { value: missing_item })
+                                .collect(),
+                        )
+                    }
+                }
+            }
+
+            // old > new
+            Ordering::Greater => {
+                if self.buffered_vector.len() <= new_limit {
+                    None
+                } else {
+                    // Let's remove the extra items.
+                    //
+                    // Optimisations:
+                    // - if `new_limit` is 0, we can emit a `VectorDiff::Clear` to remove all values
+                    //   at once,
+                    // - otherwise, we emit a bunch of `VectorDiff::PopFront`.
+                    if new_limit == 0 {
+                        Some(vec![VectorDiff::Clear])
+                    } else {
+                        Some(repeat(VectorDiff::PopFront).take(old_limit - new_limit).collect())
+                    }
+                }
+            }
+
+            // old == new
+            Ordering::Equal => {
+                // Nothing to do.
+                None
+            }
+        }
+    }
+}
+
+fn handle_diff<T: Clone>(
+    diff: VectorDiff<T>,
+    limit: usize,
+    previous_length: usize,
+    buffered_vector: &Vector<T>,
+) -> SmallVec<[VectorDiff<T>; 2]> {
+    // If the limit is zero, we have nothing to do.
+    if limit == 0 {
+        return SmallVec::new();
+    }
+
+    let index_of_limit = previous_length.saturating_sub(limit);
+    let is_full = previous_length >= limit;
+    let mut res = SmallVec::new();
+
+    match diff {
+        VectorDiff::Append { values } => {
+            let values = values.truncate_from_end(limit);
+
+            res.extend(
+                repeat(VectorDiff::PopFront).take(min(
+                    values.len(),
+                    (previous_length + values.len()).saturating_sub(limit),
+                )),
+            );
+            res.push(VectorDiff::Append { values });
+        }
+
+        VectorDiff::Clear => {
+            res.push(VectorDiff::Clear);
+        }
+
+        VectorDiff::PushFront { value } => {
+            if is_full {
+                // Ignore the diff.
+            } else {
+                // There is space for this new item.
+                res.push(VectorDiff::PushFront { value });
+            }
+        }
+
+        VectorDiff::PushBack { value } => {
+            if is_full {
+                // Create 1 free space.
+                res.push(VectorDiff::PopFront);
+            }
+
+            // There is space for this new item.
+            res.push(VectorDiff::PushBack { value });
+        }
+
+        VectorDiff::PopFront => {
+            if previous_length > limit {
+                // Pop front outside the limit, ignore the diff.
+            } else {
+                res.push(VectorDiff::PopFront);
+            }
+        }
+
+        VectorDiff::PopBack => {
+            res.push(VectorDiff::PopBack);
+
+            if previous_length > limit {
+                if let Some(diff) = buffered_vector.get(index_of_limit.saturating_sub(1)) {
+                    // There is a previously-truncated item, push front.
+                    res.push(VectorDiff::PushFront { value: diff.clone() });
+                }
+            }
+        }
+
+        VectorDiff::Insert { index, value } => {
+            if limit > previous_length || index > index_of_limit {
+                if is_full {
+                    // Create 1 free space.
+                    res.push(VectorDiff::PopFront);
+                }
+
+                // There is space for this new item.
+                res.push(VectorDiff::Insert {
+                    // Subtract 1 because `insert` adds a value compared to `previous_length`.
+                    index: (index - index_of_limit).saturating_sub(1),
+                    value,
+                });
+            } else {
+                // Insert before `limit`, ignore the diff.
+            }
+        }
+
+        VectorDiff::Set { index, value } => {
+            if index >= index_of_limit {
+                res.push(VectorDiff::Set { index: index - index_of_limit, value });
+            } else {
+                // Update before `limit`, ignore the diff.
+            }
+        }
+
+        VectorDiff::Remove { index } => {
+            if index >= index_of_limit {
+                let remove_index = index - index_of_limit;
+                res.push(VectorDiff::Remove { index: remove_index });
+
+                if remove_index != index {
+                    if let Some(diff) = buffered_vector.get(index_of_limit.saturating_sub(1)) {
+                        // There is a previously-truncated item, push front.
+                        res.push(VectorDiff::PushFront { value: diff.clone() });
+                    }
+                }
+            } else {
+                // Remove before `limit`, ignore the diff.
+            }
+        }
+
+        VectorDiff::Truncate { length: new_length } => {
+            let number_of_removed_values = min(limit, previous_length - new_length);
+
+            res.extend(repeat(VectorDiff::PopBack).take(number_of_removed_values));
+            res.extend(
+                buffered_vector
+                    .iter()
+                    .rev()
+                    .skip(limit - number_of_removed_values)
+                    .take(number_of_removed_values)
+                    .cloned()
+                    .map(|value| VectorDiff::PushFront { value }),
+            );
+        }
+
+        VectorDiff::Reset { values: new_values } => {
+            let new_values = new_values.truncate_from_end(limit);
+
+            // There is space for these new items.
+            res.push(VectorDiff::Reset { values: new_values });
+        }
+    }
+
+    res
+}
+
+trait TruncateFromEnd {
+    fn truncate_from_end(self, len: usize) -> Self;
+}
+
+impl<T> TruncateFromEnd for Vector<T>
+where
+    T: Clone,
+{
+    fn truncate_from_end(self, len: usize) -> Self {
+        if len == 0 {
+            return Vector::new();
+        }
+
+        let index = self.len().saturating_sub(len);
+
+        // Avoid calling `Vector::split_at`.
+        if index == 0 {
+            return self;
+        }
+
+        let (_left, right) = self.split_at(index);
+
+        right
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TruncateFromEnd;
+    use imbl::vector;
+
+    #[test]
+    fn test_truncate_from_end() {
+        // Length is 0.
+        assert_eq!(vector![1, 2, 3, 4].truncate_from_end(0), vector![]);
+
+        // Length is smaller than the values.
+        assert_eq!(vector![1, 2, 3, 4].truncate_from_end(1), vector![4]);
+
+        // Length is equal to the number of values.
+        assert_eq!(vector![1, 2, 3, 4].truncate_from_end(4), vector![1, 2, 3, 4]);
+
+        // Length is larger than the number of values.
+        assert_eq!(vector![1, 2, 3, 4].truncate_from_end(6), vector![1, 2, 3, 4]);
+    }
+}

--- a/eyeball-im-util/src/vector/traits.rs
+++ b/eyeball-im-util/src/vector/traits.rs
@@ -12,7 +12,7 @@ use super::{
     ops::{
         VecVectorDiffFamily, VectorDiffContainerFamily, VectorDiffContainerOps, VectorDiffFamily,
     },
-    EmptyLimitStream, Filter, FilterMap, Head, Sort, SortBy, SortByKey,
+    EmptyLimitStream, Filter, FilterMap, Head, Sort, SortBy, SortByKey, Tail,
 };
 
 /// Abstraction over stream items that the adapters in this module can deal
@@ -158,6 +158,42 @@ where
     {
         let (items, stream) = self.into_parts();
         Head::dynamic_with_initial_limit(items, stream, initial_limit, limit_stream)
+    }
+
+    /// Limit the observed values to the last `limit` values.
+    ///
+    /// See [`Tail`] for more details.
+    fn tail(self, limit: usize) -> (Vector<T>, Tail<Self::Stream, EmptyLimitStream>) {
+        let (items, stream) = self.into_parts();
+        Tail::new(items, stream, limit)
+    }
+
+    /// Limit the last observed values to a number of items determined by the
+    /// given stream.
+    ///
+    /// See [`Tail`] for more details.
+    fn dynamic_tail<L>(self, limit_stream: L) -> Tail<Self::Stream, L>
+    where
+        L: Stream<Item = usize>,
+    {
+        let (items, stream) = self.into_parts();
+        Tail::dynamic(items, stream, limit_stream)
+    }
+
+    /// Limit the last observed values to `initial_limit` items initially, and
+    /// update the limit with the value from the given stream.
+    ///
+    /// See [`Tail`] for more details.
+    fn dynamic_tail_with_initial_value<L>(
+        self,
+        initial_limit: usize,
+        limit_stream: L,
+    ) -> (Vector<T>, Tail<Self::Stream, L>)
+    where
+        L: Stream<Item = usize>,
+    {
+        let (items, stream) = self.into_parts();
+        Tail::dynamic_with_initial_limit(items, stream, initial_limit, limit_stream)
     }
 
     /// Sort the observed values.

--- a/eyeball-im-util/tests/it/main.rs
+++ b/eyeball-im-util/tests/it/main.rs
@@ -4,3 +4,4 @@ mod head;
 mod sort;
 mod sort_by;
 mod sort_by_key;
+mod tail;

--- a/eyeball-im-util/tests/it/tail.rs
+++ b/eyeball-im-util/tests/it/tail.rs
@@ -1,0 +1,1207 @@
+use eyeball::Observable;
+use eyeball_im::{ObservableVector, VectorDiff};
+use eyeball_im_util::vector::VectorObserverExt;
+use imbl::vector;
+use stream_assert::{assert_closed, assert_next_eq, assert_pending};
+
+#[test]
+fn static_limit() {
+    let mut ob: ObservableVector<usize> = ObservableVector::from(vector![1, 20, 300]);
+    let (limited, mut sub) = ob.subscribe().tail(2);
+    assert_eq!(limited, vector![20, 300]);
+    assert_pending!(sub);
+
+    // `1` is removed, it's outside the limit window, we get nothing on `sub`.
+    ob.pop_front();
+    assert_pending!(sub);
+
+    // `200` is removed, it's within the limit window, we get a `PopFront` on `sub`.
+    ob.pop_front();
+    assert_next_eq!(sub, VectorDiff::PopFront);
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn pending_until_limit_emits_a_value() {
+    let mut ob: ObservableVector<usize> = ObservableVector::new();
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    // Append new values…
+    ob.append(vector![10, 11, 12, 13, 14, 15]);
+
+    // … but it's still pending…
+    assert_pending!(sub);
+
+    // … because the `limit` stream didn't produce any value yet.
+    // Let's change that.
+    Observable::set(&mut limit, 3);
+
+    // Here we are.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![13, 14, 15] });
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn update_limit_before_polling_sub() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    // Append 4 values.
+    ob.append(vector![10, 11, 12, 13]);
+
+    // Observe nothing because the limit is still 0.
+    assert_pending!(sub);
+
+    // Set limit to 2.
+    Observable::set(&mut limit, 2);
+
+    // Observe 2 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![12, 13] });
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn update_limit_after_polling_sub() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    // Append 4 values.
+    ob.append(vector![10, 11, 12, 13]);
+
+    // Set limit to 2.
+    Observable::set(&mut limit, 2);
+
+    // Observe 2 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![12, 13] });
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn increase_and_decrease_the_limit_on_an_empty_stream() {
+    let ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(1);
+    let (limited, mut sub) =
+        ob.subscribe().dynamic_tail_with_initial_value(1, Observable::subscribe(&limit));
+
+    assert!(limited.is_empty());
+
+    // `ob` is empty!
+
+    // Set limit to 2.
+    Observable::set(&mut limit, 2);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Set limit to 1.
+    Observable::set(&mut limit, 1);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn increase_and_decrease_the_limit_only() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    // Append 4 values.
+    ob.append(vector![10, 11, 12, 13]);
+
+    // Observe nothing because the limit is still 0.
+    assert_pending!(sub);
+
+    // Set limit to 2.
+    Observable::set(&mut limit, 2);
+
+    // Observe 2 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![12, 13] });
+
+    // Set limit to 4.
+    Observable::set(&mut limit, 4);
+
+    // Observe 2 more values.
+    assert_next_eq!(sub, VectorDiff::PushFront { value: 11 });
+    assert_next_eq!(sub, VectorDiff::PushFront { value: 10 });
+
+    // Set limit to 6.
+    Observable::set(&mut limit, 6);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Set limit to 5.
+    Observable::set(&mut limit, 5);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Set limit to 2.
+    Observable::set(&mut limit, 2);
+
+    // Observe a truncation.
+    assert_next_eq!(sub, VectorDiff::PopFront);
+    assert_next_eq!(sub, VectorDiff::PopFront);
+    assert_next_eq!(sub, VectorDiff::PopFront);
+
+    // Set limit to 0.
+    Observable::set(&mut limit, 0);
+
+    // Observe a `VectorDiff::Clear` is emitted as an optimisation instead of
+    // emitting a bunch of `VectorDiff::PopFront`.
+    assert_next_eq!(sub, VectorDiff::Clear);
+
+    // Set limit to 5.
+    Observable::set(&mut limit, 5);
+
+    // Observe all available values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![10, 11, 12, 13] });
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn limit_is_zero() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    // Append 4 values.
+    ob.append(vector![10, 11, 12, 13]);
+
+    // Set limit to 0.
+    Observable::set(&mut limit, 0);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Add 1 value.
+    ob.push_back(14);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Set limit to 5.
+    Observable::set(&mut limit, 5);
+
+    // Observe 5 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![10, 11, 12, 13, 14] });
+
+    // Set limit to 0 again.
+    Observable::set(&mut limit, 0);
+
+    // Observe a truncation.
+    assert_next_eq!(sub, VectorDiff::Clear);
+
+    // Add 1 value.
+    ob.push_back(15);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn limit_is_polled_first() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    // Append 4 values.
+    ob.append(vector![10, 11, 12, 13]);
+
+    // Set limit to 3.
+    Observable::set(&mut limit, 3);
+
+    // Observe 3 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![11, 12, 13] });
+
+    // Add 1 value on the back…
+    ob.push_back(14);
+
+    // … and set limit to 2 _after_.
+    Observable::set(&mut limit, 2);
+
+    // However, let's observe the limit's change _first_…
+    assert_next_eq!(sub, VectorDiff::PopFront);
+
+    // … and let's observe the other updates _after_.
+    assert_next_eq!(sub, VectorDiff::PopFront);
+    assert_next_eq!(sub, VectorDiff::PushBack { value: 14 });
+    assert_pending!(sub);
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn append() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    // We need to test appending values where the number of values compares to limit
+    // and the vector's length as follows:
+    //
+    // | limit | vector's length | test case |
+    // |-------|-----------------|-----------|
+    // | less  | less            | #1        |
+    // | less  | more            | #2        |
+    // | more  | less            | #3        |
+    // | more  | more            | #4        |
+
+    Observable::set(&mut limit, 4);
+
+    // Test case #2.
+    //
+    // Append less values than the limit, but more values than the vector's length.
+    {
+        ob.append(vector![10, 11, 12]);
+
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![10, 11, 12] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12 ]
+        // - the “view”: [ _, 10, 11, 12 ]
+    }
+
+    // Test case #4.
+    //
+    // Append more values than the limit and the vector's length.
+    {
+        ob.append(vector![13, 14, 15, 16, 17]);
+
+        assert_next_eq!(sub, VectorDiff::PopFront); // 10
+        assert_next_eq!(sub, VectorDiff::PopFront); // 11
+        assert_next_eq!(sub, VectorDiff::PopFront); // 12
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![14, 15, 16, 17] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15, 16, 17 ]
+        // - the “view”: [ 14, 15, 16, 17 ]
+    }
+
+    // Test case #1.
+    //
+    // Append less values than the limit and the vector's length.
+    {
+        ob.append(vector![18, 19]);
+
+        assert_next_eq!(sub, VectorDiff::PopFront); // 13
+        assert_next_eq!(sub, VectorDiff::PopFront); // 14
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![18, 19] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 ]
+        // - the “view”: [ 16, 17, 18, 19 ]
+    }
+
+    // Test case #3.
+    //
+    // Append more values than the limit, but less values the vector's length.
+    {
+        Observable::set(&mut limit, 2);
+
+        assert_next_eq!(sub, VectorDiff::PopFront); // 16
+        assert_next_eq!(sub, VectorDiff::PopFront); // 17
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 ]
+        // - the “view”: [ 18, 19 ]
+
+        ob.append(vector![20, 21, 22]);
+
+        assert_next_eq!(sub, VectorDiff::PopFront); // 18
+        assert_next_eq!(sub, VectorDiff::PopFront); // 19
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![21, 22] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22 ]
+        // - the “view”: [ 21, 22 ]
+    }
+
+    assert_pending!(sub);
+
+    // Check the content of the vector.
+    {
+        let expected = vector![10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn clear() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    // Set limit to 4.
+    Observable::set(&mut limit, 4);
+
+    // Add 1 value.
+    ob.push_back(10);
+
+    // Clear.
+    ob.clear();
+
+    // Observe the updates.
+    assert_next_eq!(sub, VectorDiff::PushBack { value: 10 });
+    assert_next_eq!(sub, VectorDiff::Clear);
+
+    // Check the content of the vector.
+    {
+        let expected = vector![];
+        assert_eq!(*ob, expected);
+    }
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn push_front() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    // Set limit to 2.
+    Observable::set(&mut limit, 2);
+
+    // Vector is empty and limit is polled for the first time.
+    {
+        ob.push_front(10);
+
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 10 });
+
+        // State of:
+        //
+        // - the vector: [ 10 ]
+        // - the “view”: [ 10 ]
+    }
+
+    // Push front, the limit is not reached yet.
+    {
+        ob.push_front(11);
+
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 11 });
+
+        // State of:
+        //
+        // - the vector: [ 11, 10 ]
+        // - the “view”: [ 11, 10 ]
+    }
+
+    // Push front, it happens outside the limit, nothing happens.
+    {
+        ob.push_front(12);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 12, 11, 10 ]
+        // - the “view”: [ 11, 10 ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![12, 11, 10];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn push_back() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    // Set limit to 2.
+    Observable::set(&mut limit, 2);
+
+    // Vector is empty and limit is polled for the first time.
+    {
+        ob.push_back(10);
+
+        assert_next_eq!(sub, VectorDiff::PushBack { value: 10 });
+
+        // State of:
+        //
+        // - the vector: [ 10 ]
+        // - the “view”: [ 10 ]
+    }
+
+    // Push back, the limit is not reached yet.
+    {
+        ob.push_back(11);
+
+        assert_next_eq!(sub, VectorDiff::PushBack { value: 11 });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11 ]
+        // - the “view”: [ 10, 11 ]
+    }
+
+    // Push back, the view is full, a value needs to be removed.
+    {
+        ob.push_back(12);
+
+        assert_next_eq!(sub, VectorDiff::PopFront);
+        assert_next_eq!(sub, VectorDiff::PushBack { value: 12 });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12 ]
+        // - the “view”: [ 11, 12 ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![10, 11, 12];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn pop_front() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    // Init state.
+    {
+        ob.append(vector![10, 11, 12]);
+        Observable::set(&mut limit, 2);
+
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![11, 12] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12 ]
+        // - the “view”: [ 11, 12 ]
+    }
+
+    // Pop front, it happens outside the view, nothing happens.
+    {
+        ob.pop_front(); // 10
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 11, 12 ]
+        // - the “view”: [ 11, 12 ]
+    }
+
+    // Pop front, it happens inside the view.
+    {
+        ob.pop_front(); // 11
+
+        assert_next_eq!(sub, VectorDiff::PopFront);
+
+        // State of:
+        //
+        // - the vector: [ 12 ]
+        // - the “view”: [ 12 ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![12];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn pop_back() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    // Init state.
+    {
+        ob.append(vector![10, 11, 12]);
+        Observable::set(&mut limit, 2);
+
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![11, 12] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12 ]
+        // - the “view”: [ 11, 12 ]
+    }
+
+    // Pop back, the buffer has a value to fill the view.
+    {
+        ob.pop_back(); // 12
+
+        assert_next_eq!(sub, VectorDiff::PopBack);
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 10 });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11 ]
+        // - the “view”: [ 10, 11 ]
+    }
+
+    // Pop back, the buffer has no value to fill the view.
+    {
+        ob.pop_back(); // 11
+
+        assert_next_eq!(sub, VectorDiff::PopBack);
+
+        // State of:
+        //
+        // - the vector: [ 10 ]
+        // - the “view”: [ 10 ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![10];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn insert() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    Observable::set(&mut limit, 2);
+
+    // Insert at 0, on an empty vector.
+    {
+        ob.insert(0, 10);
+
+        assert_next_eq!(sub, VectorDiff::Insert { index: 0, value: 10 });
+
+        // State of:
+        //
+        // - the vector: [ 10 ]
+        // - the “view”: [ 10 ]
+    }
+
+    // Insert at 0, on a non-empty vector, still inside the view.
+    {
+        ob.insert(0, 11);
+
+        assert_next_eq!(sub, VectorDiff::Insert { index: 0, value: 11 });
+
+        // State of:
+        //
+        // - the vector: [ 11, 10 ]
+        // - the “view”: [ 11, 10 ]
+    }
+
+    // Insert at 0, on a non-empty vector, but this time, outside the view.
+    {
+        ob.insert(0, 12);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 12, 11, 10 ]
+        // - the “view”: [ 11, 10 ]
+    }
+
+    // Insert outside the view, nothing happens.
+    {
+        ob.insert(1, 13);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 12, 13, 11, 10 ]
+        // - the “view”: [ 11, 10 ]
+    }
+
+    // Insert outside the view (exactly at the limit, to test off-by-one), nothing
+    // happens.
+    {
+        ob.insert(2, 14);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 12, 13, 14, 11, 10 ]
+        // - the “view”: [ 11, 10 ]
+    }
+
+    // Insert inside the view.
+    {
+        ob.insert(4, 15);
+
+        assert_next_eq!(sub, VectorDiff::PopFront);
+        assert_next_eq!(sub, VectorDiff::Insert { index: 0, value: 15 });
+
+        // State of:
+        //
+        // - the vector: [ 12, 13, 14, 11, 15, 10 ]
+        // - the “view”: [ 15, 10 ]
+    }
+
+    // Insert inside a larger view.
+    {
+        Observable::set(&mut limit, 4);
+
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 11 });
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 14 });
+
+        // State of:
+        //
+        // - the vector: [ 12, 13, 14, 11, 15, 10 ]
+        // - the “view”: [ 14, 11, 15, 10 ]
+
+        ob.insert(4, 16);
+
+        assert_next_eq!(sub, VectorDiff::PopFront); // 14
+        assert_next_eq!(sub, VectorDiff::Insert { index: 1, value: 16 });
+
+        // State of:
+        //
+        // - the vector: [ 12, 13, 14, 16, 11, 15, 10 ]
+        // - the “view”: [ 11, 16, 15, 10 ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![12, 13, 14, 11, 16, 15, 10];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn set() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    // Init state.
+    {
+        ob.append(vector![10, 11, 12]);
+        Observable::set(&mut limit, 2);
+
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![11, 12] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12 ]
+        // - the “view”: [ 11, 12 ]
+    }
+
+    // Set outside the view, nothing happens.
+    {
+        ob.set(0, 20);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 20, 11, 12 ]
+        // - the “view”: [ 11, 12 ]
+    }
+
+    // Set inside the view.
+    {
+        ob.set(1, 21);
+
+        assert_next_eq!(sub, VectorDiff::Set { index: 0, value: 21 });
+
+        // State of:
+        //
+        // - the vector: [ 20, 21, 12 ]
+        // - the “view”: [ 21, 12 ]
+    }
+
+    // Set inside a larger view.
+    {
+        Observable::set(&mut limit, 4);
+
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 20 });
+
+        // State of:
+        //
+        // - the vector: [ 20, 21, 12 ]
+        // - the “view”: [ _, 20, 21, 12 ]
+
+        ob.append(vector![13, 14, 15]);
+
+        assert_next_eq!(sub, VectorDiff::PopFront);
+        assert_next_eq!(sub, VectorDiff::PopFront);
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![13, 14, 15] });
+
+        // State of:
+        //
+        // - the vector: [ 20, 21, 12, 13, 14, 15 ]
+        // - the “view”: [ 12, 13, 14, 15 ]
+
+        ob.set(4, 24);
+
+        assert_next_eq!(sub, VectorDiff::Set { index: 2, value: 24 });
+
+        // State of:
+        //
+        // - the vector: [ 20, 21, 12, 13, 24, 15 ]
+        // - the “view”: [ 12, 13, 24, 15 ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![20, 21, 12, 13, 24, 15];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn remove() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    // Init state.
+    {
+        ob.append(vector![10, 11, 12, 13, 14, 15]);
+        Observable::set(&mut limit, 4);
+
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![12, 13, 14, 15] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15 ]
+        // - the “view”: [ 12, 13, 14, 15 ]
+    }
+
+    // Remove outside the limit.
+    {
+        ob.remove(1);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 10, 12, 13, 14, 15 ]
+        // - the “view”: [ 12, 13, 14, 15 ]
+    }
+
+    // Remove inside the limit, the buffer has a value to fill the view.
+    {
+        ob.remove(1);
+
+        assert_next_eq!(sub, VectorDiff::Remove { index: 0 }); // 12
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 10 });
+
+        // State of:
+        //
+        // - the vector: [ 10, 13, 14, 15 ]
+        // - the “view”: [ 10, 13, 14, 15 ]
+    }
+
+    // Remove inside the limit, the buffer has no value to fill the view.
+    {
+        ob.remove(1);
+
+        assert_next_eq!(sub, VectorDiff::Remove { index: 1 }); // 13
+        assert_pending!(sub); // and that's it!
+
+        // State of:
+        //
+        // - the vector: [ 10, 14, 15 ]
+        // - the “view”: [ 10, 14, 15 ]
+    }
+
+    // Remove inside the limit, the buffer has no value to fill the view, and the
+    // limit is larger than the buffer.
+    {
+        ob.remove(1);
+
+        assert_next_eq!(sub, VectorDiff::Remove { index: 1 }); // 14
+        assert_pending!(sub); // and that's it!
+
+        // State of:
+        //
+        // - the vector: [ 10, 15 ]
+        // - the “view”: [ 10, 15 ]
+    }
+
+    // Remove again.
+    {
+        ob.remove(0);
+
+        assert_next_eq!(sub, VectorDiff::Remove { index: 0 }); // 10
+
+        // State of:
+        //
+        // - the vector: [ 15 ]
+        // - the “view”: [ 15 ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![15];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn truncate() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    // Truncate to a size that compares to the limit as follows:
+    //
+    // | compares to the limit | values to fill in | test case  |
+    // |-----------------------|-------------------|------------|
+    // | larger                | yes               | #1         |
+    // | equal                 | yes               | #2         |
+    // | smaller               | yes               | #3         |
+    // | larger                | no                | impossible |
+    // | equal                 | no                | impossible |
+    // | smaller               | no                | #4         |
+    //
+    // Why is it _impossible_ to truncate to a size larger or equal to the limit,
+    // with no buffer values to fill in? To get no buffer values available to fill
+    // in the view, we need the limit to be greater than or equal to the size of the
+    // vector. As such, the truncate size must be larger than the size of the
+    // vector, which is a no-op: reading the documentation of
+    // `ObservableVector::truncate`, it tells it does nothing.
+
+    // Init state.
+    {
+        ob.append(vector![10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]);
+        Observable::set(&mut limit, 4);
+
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![18, 19, 20, 21] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21 ]
+        // - the “view”: [ 18, 19, 20, 21 ]
+    }
+
+    // Test case #1.
+    //
+    // Truncate to a size that is larger than the limit, the buffer has values to
+    // fill the view.
+    {
+        ob.truncate(10);
+
+        assert_next_eq!(sub, VectorDiff::PopBack); // 21
+        assert_next_eq!(sub, VectorDiff::PopBack); // 20
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 17 });
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 16 });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 ]
+        // - the “view”: [ 16, 17, 18, 19 ]
+    }
+
+    // Test case #2.
+    //
+    // Truncate to a size that is equal to the limit, the buffer has values to fill
+    // the view.
+    {
+        Observable::set(&mut limit, 8);
+
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 15 });
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 14 });
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 13 });
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 12 });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 ]
+        // - the “view”: [ 12, 13, 14, 15, 16, 17, 18, 19 ]
+
+        ob.truncate(8);
+
+        assert_next_eq!(sub, VectorDiff::PopBack); // 19
+        assert_next_eq!(sub, VectorDiff::PopBack); // 18
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 11 });
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 10 });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15, 16, 17 ]
+        // - the “view”: [ 10, 11, 12, 13, 14, 15, 16, 17 ]
+    }
+
+    // Test case #3.
+    //
+    // Truncate to a size that is lower to the limit, the buffer has values to fill
+    // the view.
+    {
+        Observable::set(&mut limit, 7);
+
+        assert_next_eq!(sub, VectorDiff::PopFront);
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15, 16, 17 ]
+        // - the “view”: [ 11, 12, 13, 14, 15, 16, 17 ]
+
+        ob.truncate(6);
+
+        assert_next_eq!(sub, VectorDiff::PopBack); // 17
+        assert_next_eq!(sub, VectorDiff::PopBack); // 16
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 10 });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15 ]
+        // - the “view”: [ 10, 11, 12, 13, 14, 15 ]
+    }
+
+    // Test case #4.
+    //
+    // Truncate to a size that is smaller than the limit, the buffer has no values
+    // to fill the view.
+    {
+        Observable::set(&mut limit, 8);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15 ]
+        // - the “view”: [ _, _, 10, 11, 12, 13, 14, 15 ]
+
+        ob.truncate(3);
+
+        assert_next_eq!(sub, VectorDiff::PopBack); // 15
+        assert_next_eq!(sub, VectorDiff::PopBack); // 14
+        assert_next_eq!(sub, VectorDiff::PopBack); // 13
+        assert_pending!(sub); // that's it!
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12 ]
+        // - the “view”: [ _, _, _, _, _, 10, 11, 12 ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![10, 11, 12];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn reset() {
+    let mut ob = ObservableVector::<usize>::with_capacity(2);
+    let mut limit = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_tail(Observable::subscribe(&limit));
+
+    // Init state.
+    {
+        ob.append(vector![10, 11, 12, 13, 14, 15]);
+        Observable::set(&mut limit, 4);
+
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![12, 13, 14, 15] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15 ]
+        // - the “view”: [ 12, 13, 14, 15 ]
+    }
+
+    // Do multiple operations to saturate the observable capacity, in order to
+    // trigger a reset.
+    {
+        ob.push_back(16);
+        ob.push_back(17);
+        ob.push_back(18);
+    }
+
+    // Observe a reset, capped to the limit.
+    {
+        assert_next_eq!(sub, VectorDiff::Reset { values: vector![15, 16, 17, 18] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15, 16, 17, 18 ]
+        // - the “view”: [ 15, 16, 17, 18 ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![10, 11, 12, 13, 14, 15, 16, 17, 18];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut limit, 0);
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        Observable::set(&mut limit, 42);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+// This test is copied (and modified to match the behaviour of `Tail`) from
+// `Head`'s test suite. The bug is not present in `Tail`, but since their
+// behaviours are quite similar, let's ensure the bug cannot happen
+// preemptively.
+#[tokio::test]
+async fn limit_stream_wake() {
+    use futures_util::{FutureExt, StreamExt};
+    use tokio::task::yield_now;
+
+    let ob = ObservableVector::<u32>::from(vector![1, 2]);
+    let mut limit = Observable::new(1);
+    let (values, mut sub) =
+        ob.subscribe().dynamic_tail_with_initial_value(1, Observable::subscribe(&limit));
+
+    assert_eq!(values, vector![2]);
+
+    let task_hdl = tokio::spawn(async move {
+        let update = sub.next().await.unwrap();
+        assert_eq!(update, VectorDiff::PushFront { value: 1 });
+    });
+
+    // Set the limit to the same value that `Tail` has already seen.
+    Observable::set(&mut limit, 1);
+
+    // Make sure the task spawned above sees the "updated" limit.
+    yield_now().await;
+
+    // Now update the limit again.
+    Observable::set(&mut limit, 2);
+
+    // Allow the task to make progress.
+    yield_now().await;
+
+    // It should be finished now.
+    task_hdl.now_or_never().unwrap().unwrap();
+}


### PR DESCRIPTION
This patch adds the `Tail` higher-order stream. Similarly to `Head`,
it computes a limited view of the underlying `ObservableVector`'s
items, however the view starts from the end —instead of the start— of
the `ObservableVector`.

```rust
use eyeball_im::{ObservableVector, VectorDiff};
use eyeball_im_util::vector::VectorObserverExt;
use imbl::vector;
use stream_assert::{assert_closed, assert_next_eq, assert_pending};

// Our vector.
let mut ob = ObservableVector::<char>::new();
let (values, mut sub) = ob.subscribe().tail(3);

assert!(values.is_empty());
assert_pending!(sub);

// Append multiple values.
ob.append(vector!['a', 'b', 'c', 'd']);
// We get a `VectorDiff::Append` with the latest 3 values!
assert_next_eq!(sub, VectorDiff::Append { values: vector!['b', 'c', 'd'] });

// Let's recap what we have. `ob` is our `ObservableVector`,
// `sub` is the “limited view” of `ob`:
// | `ob`  | a b c d |
// | `sub` |   b c d |

// Append multiple other values.
ob.append(vector!['e', 'f']);
// We get three `VectorDiff`s!
assert_next_eq!(sub, VectorDiff::PopFront);
assert_next_eq!(sub, VectorDiff::PopFront);
assert_next_eq!(sub, VectorDiff::Append { values: vector!['e', 'f'] });

// Let's recap what we have:
// | `ob`  | a b c d e f |
// | `sub` |       d e f |
//             ^ ^   ^^^
//             | |   |
//             | |   added with `VectorDiff::Append { .. }`
//             | removed with `VectorDiff::PopFront`
//             removed with `VectorDiff::PopFront`

assert_pending!(sub);
drop(ob);
assert_closed!(sub);
```

---

* Built on top of #70, should be merged after