### PR TITLE
chore: Rename `Limit` to `Head`

### DIFF
--- a/eyeball-im-util/CHANGELOG.md
+++ b/eyeball-im-util/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Rename `Limit` to `Head`, along with all the similar methods, like
+  `VectorObserverExt::limit` which becomes `VectorObserverExt::head` and so on.
+
 # 0.7.0
 
 - Remove `Send` and `Sync` constraints from some traits and associated types

--- a/eyeball-im-util/src/vector.rs
+++ b/eyeball-im-util/src/vector.rs
@@ -1,7 +1,7 @@
 //! Utilities around [`ObservableVector`][eyeball_im::ObservableVector].
 
 mod filter;
-mod limit;
+mod head;
 mod ops;
 mod sort;
 mod traits;
@@ -12,7 +12,7 @@ use futures_core::Stream;
 use self::ops::{VectorDiffContainerFamilyMember, VectorDiffContainerOps};
 pub use self::{
     filter::{Filter, FilterMap},
-    limit::{EmptyLimitStream, Limit},
+    head::{EmptyLimitStream, Head},
     sort::{Sort, SortBy, SortByKey},
     traits::{
         BatchedVectorSubscriber, VectorDiffContainer, VectorObserver, VectorObserverExt,
@@ -41,9 +41,9 @@ type VectorDiffContainerStreamFamily<S> =
 type VectorDiffContainerDiff<S> = VectorDiff<VectorDiffContainerStreamElement<S>>;
 
 /// Type alias for extracting the buffer type from a stream of
-/// [`VectorDiffContainer`]s' `LimitBuf`.
-type VectorDiffContainerStreamLimitBuf<S> =
-    <<S as Stream>::Item as VectorDiffContainerOps<VectorDiffContainerStreamElement<S>>>::LimitBuf;
+/// [`VectorDiffContainer`]s' `HeadBuf`.
+type VectorDiffContainerStreamHeadBuf<S> =
+    <<S as Stream>::Item as VectorDiffContainerOps<VectorDiffContainerStreamElement<S>>>::HeadBuf;
 
 /// Type alias for extracting the buffer type from a stream of
 /// [`VectorDiffContainer`]s' `SortBuf`.

--- a/eyeball-im-util/src/vector/traits.rs
+++ b/eyeball-im-util/src/vector/traits.rs
@@ -12,7 +12,7 @@ use super::{
     ops::{
         VecVectorDiffFamily, VectorDiffContainerFamily, VectorDiffContainerOps, VectorDiffFamily,
     },
-    EmptyLimitStream, Filter, FilterMap, Limit, Sort, SortBy, SortByKey,
+    EmptyLimitStream, Filter, FilterMap, Head, Sort, SortBy, SortByKey,
 };
 
 /// Abstraction over stream items that the adapters in this module can deal
@@ -124,40 +124,40 @@ where
         FilterMap::new(items, stream, f)
     }
 
-    /// Limit the observed values to `limit`.
+    /// Limit the observed values to the first `limit` values.
     ///
-    /// See [`Limit`] for more details.
-    fn limit(self, limit: usize) -> (Vector<T>, Limit<Self::Stream, EmptyLimitStream>) {
+    /// See [`Head`] for more details.
+    fn head(self, limit: usize) -> (Vector<T>, Head<Self::Stream, EmptyLimitStream>) {
         let (items, stream) = self.into_parts();
-        Limit::new(items, stream, limit)
+        Head::new(items, stream, limit)
     }
 
-    /// Limit the observed values to a number of items determined by the given
-    /// stream.
+    /// Limit the first observed values to a number of values determined by the
+    /// given stream.
     ///
-    /// See [`Limit`] for more details.
-    fn dynamic_limit<L>(self, limit_stream: L) -> Limit<Self::Stream, L>
+    /// See [`Head`] for more details.
+    fn dynamic_head<L>(self, limit_stream: L) -> Head<Self::Stream, L>
     where
         L: Stream<Item = usize>,
     {
         let (items, stream) = self.into_parts();
-        Limit::dynamic(items, stream, limit_stream)
+        Head::dynamic(items, stream, limit_stream)
     }
 
-    /// Limit the observed values to `initial_limit` items initially, and update
-    /// the limit with the value from the given stream.
+    /// Limit the first observed values to `initial_limit` values initially, and
+    /// update the limit with the value from the given stream.
     ///
-    /// See [`Limit`] for more details.
-    fn dynamic_limit_with_initial_value<L>(
+    /// See [`Head`] for more details.
+    fn dynamic_head_with_initial_value<L>(
         self,
         initial_limit: usize,
         limit_stream: L,
-    ) -> (Vector<T>, Limit<Self::Stream, L>)
+    ) -> (Vector<T>, Head<Self::Stream, L>)
     where
         L: Stream<Item = usize>,
     {
         let (items, stream) = self.into_parts();
-        Limit::dynamic_with_initial_limit(items, stream, initial_limit, limit_stream)
+        Head::dynamic_with_initial_limit(items, stream, initial_limit, limit_stream)
     }
 
     /// Sort the observed values.

--- a/eyeball-im-util/tests/it/head.rs
+++ b/eyeball-im-util/tests/it/head.rs
@@ -7,7 +7,7 @@ use stream_assert::{assert_closed, assert_next_eq, assert_pending};
 #[test]
 fn static_limit() {
     let mut ob: ObservableVector<usize> = ObservableVector::from(vector![1, 20, 300]);
-    let (limited, mut sub) = ob.subscribe().limit(2);
+    let (limited, mut sub) = ob.subscribe().head(2);
     assert_eq!(limited, vector![1, 20]);
     assert_pending!(sub);
 
@@ -22,7 +22,7 @@ fn static_limit() {
 fn pending_until_limit_emits_a_value() {
     let mut ob: ObservableVector<usize> = ObservableVector::new();
     let mut limit = Observable::new(0);
-    let mut sub = ob.subscribe().dynamic_limit(Observable::subscribe(&limit));
+    let mut sub = ob.subscribe().dynamic_head(Observable::subscribe(&limit));
 
     // Append new values…
     ob.append(vector![10, 11, 12]);
@@ -46,7 +46,7 @@ fn increase_and_decrease_the_limit_on_an_empty_stream() {
     let ob = ObservableVector::<usize>::new();
     let mut limit = Observable::new(1);
     let (limited, mut sub) =
-        ob.subscribe().dynamic_limit_with_initial_value(1, Observable::subscribe(&limit));
+        ob.subscribe().dynamic_head_with_initial_value(1, Observable::subscribe(&limit));
 
     assert!(limited.is_empty());
 
@@ -72,7 +72,7 @@ fn increase_and_decrease_the_limit_on_an_empty_stream() {
 fn increase_and_decrease_the_limit_only() {
     let mut ob = ObservableVector::<usize>::new();
     let mut limit = Observable::new(0);
-    let mut sub = ob.subscribe().dynamic_limit(Observable::subscribe(&limit));
+    let mut sub = ob.subscribe().dynamic_head(Observable::subscribe(&limit));
 
     // Append 4 values.
     ob.append(vector![10, 11, 12, 13]);
@@ -127,7 +127,7 @@ fn increase_and_decrease_the_limit_only() {
 fn limit_is_zero() {
     let mut ob = ObservableVector::<usize>::new();
     let mut limit = Observable::new(0);
-    let mut sub = ob.subscribe().dynamic_limit(Observable::subscribe(&limit));
+    let mut sub = ob.subscribe().dynamic_head(Observable::subscribe(&limit));
 
     // Append 4 values.
     ob.append(vector![10, 11, 12, 13]);
@@ -170,7 +170,7 @@ fn limit_is_zero() {
 fn limit_is_polled_first() {
     let mut ob = ObservableVector::<usize>::new();
     let mut limit = Observable::new(0);
-    let mut sub = ob.subscribe().dynamic_limit(Observable::subscribe(&limit));
+    let mut sub = ob.subscribe().dynamic_head(Observable::subscribe(&limit));
 
     // Append 4 values.
     ob.append(vector![10, 11, 12, 13]);
@@ -203,7 +203,7 @@ fn limit_is_polled_first() {
 fn append() {
     let mut ob = ObservableVector::<usize>::new();
     let mut limit = Observable::new(0);
-    let mut sub = ob.subscribe().dynamic_limit(Observable::subscribe(&limit));
+    let mut sub = ob.subscribe().dynamic_head(Observable::subscribe(&limit));
 
     // Set limit to 4.
     Observable::set(&mut limit, 4);
@@ -258,7 +258,7 @@ fn append() {
 fn clear() {
     let mut ob = ObservableVector::<usize>::new();
     let mut limit = Observable::new(0);
-    let mut sub = ob.subscribe().dynamic_limit(Observable::subscribe(&limit));
+    let mut sub = ob.subscribe().dynamic_head(Observable::subscribe(&limit));
 
     // Set limit to 4.
     Observable::set(&mut limit, 4);
@@ -287,7 +287,7 @@ fn clear() {
 fn push_front() {
     let mut ob = ObservableVector::<usize>::new();
     let mut limit = Observable::new(0);
-    let mut sub = ob.subscribe().dynamic_limit(Observable::subscribe(&limit));
+    let mut sub = ob.subscribe().dynamic_head(Observable::subscribe(&limit));
 
     // Set limit to 2.
     Observable::set(&mut limit, 2);
@@ -339,7 +339,7 @@ fn push_front() {
 fn push_back() {
     let mut ob = ObservableVector::<usize>::new();
     let mut limit = Observable::new(0);
-    let mut sub = ob.subscribe().dynamic_limit(Observable::subscribe(&limit));
+    let mut sub = ob.subscribe().dynamic_head(Observable::subscribe(&limit));
 
     // Set limit to 2.
     Observable::set(&mut limit, 2);
@@ -388,7 +388,7 @@ fn push_back() {
 fn pop_front() {
     let mut ob = ObservableVector::<usize>::new();
     let mut limit = Observable::new(0);
-    let mut sub = ob.subscribe().dynamic_limit(Observable::subscribe(&limit));
+    let mut sub = ob.subscribe().dynamic_head(Observable::subscribe(&limit));
 
     // Add 4 values.
     ob.append(vector![10, 11, 12, 13]);
@@ -440,7 +440,7 @@ fn pop_front() {
 fn pop_back() {
     let mut ob = ObservableVector::<usize>::new();
     let mut limit = Observable::new(0);
-    let mut sub = ob.subscribe().dynamic_limit(Observable::subscribe(&limit));
+    let mut sub = ob.subscribe().dynamic_head(Observable::subscribe(&limit));
 
     // Add 4 values.
     ob.append(vector![10, 11, 12, 13]);
@@ -489,7 +489,7 @@ fn pop_back() {
 fn insert() {
     let mut ob = ObservableVector::<usize>::new();
     let mut limit = Observable::new(0);
-    let mut sub = ob.subscribe().dynamic_limit(Observable::subscribe(&limit));
+    let mut sub = ob.subscribe().dynamic_head(Observable::subscribe(&limit));
 
     // Add 2 values.
     ob.append(vector![10, 11]);
@@ -546,7 +546,7 @@ fn insert() {
 fn set() {
     let mut ob = ObservableVector::<usize>::new();
     let mut limit = Observable::new(0);
-    let mut sub = ob.subscribe().dynamic_limit(Observable::subscribe(&limit));
+    let mut sub = ob.subscribe().dynamic_head(Observable::subscribe(&limit));
 
     // Add 3 values.
     ob.append(vector![10, 11, 12]);
@@ -595,7 +595,7 @@ fn set() {
 fn remove() {
     let mut ob = ObservableVector::<usize>::new();
     let mut limit = Observable::new(0);
-    let mut sub = ob.subscribe().dynamic_limit(Observable::subscribe(&limit));
+    let mut sub = ob.subscribe().dynamic_head(Observable::subscribe(&limit));
 
     // Add 5 values.
     ob.append(vector![10, 11, 12, 13, 14]);
@@ -647,7 +647,7 @@ fn remove() {
 fn truncate() {
     let mut ob = ObservableVector::<usize>::new();
     let mut limit = Observable::new(0);
-    let mut sub = ob.subscribe().dynamic_limit(Observable::subscribe(&limit));
+    let mut sub = ob.subscribe().dynamic_head(Observable::subscribe(&limit));
 
     // Add 5 values.
     ob.append(vector![10, 11, 12, 13, 14]);
@@ -696,7 +696,7 @@ fn truncate() {
 fn reset() {
     let mut ob = ObservableVector::<usize>::with_capacity(2);
     let mut limit = Observable::new(0);
-    let mut sub = ob.subscribe().dynamic_limit(Observable::subscribe(&limit));
+    let mut sub = ob.subscribe().dynamic_head(Observable::subscribe(&limit));
 
     // Add 1 value.
     ob.append(vector![10]);
@@ -741,7 +741,7 @@ async fn limit_stream_wake_bug() {
     let ob = ObservableVector::<u32>::from(vector![1, 2]);
     let mut limit = Observable::new(1);
     let (values, mut sub) =
-        ob.subscribe().dynamic_limit_with_initial_value(1, Observable::subscribe(&limit));
+        ob.subscribe().dynamic_head_with_initial_value(1, Observable::subscribe(&limit));
 
     assert_eq!(values, vector![1]);
 
@@ -750,7 +750,7 @@ async fn limit_stream_wake_bug() {
         assert_eq!(update, VectorDiff::Append { values: vector![2] });
     });
 
-    // Set the limit to the same value that `Limit` has already seen.
+    // Set the limit to the same value that `Head` has already seen.
     Observable::set(&mut limit, 1);
 
     // Make sure the task spawned above sees the "updated" limit.

--- a/eyeball-im-util/tests/it/main.rs
+++ b/eyeball-im-util/tests/it/main.rs
@@ -1,6 +1,6 @@
 mod filter;
 mod filter_map;
-mod limit;
+mod head;
 mod sort;
 mod sort_by;
 mod sort_by_key;


### PR DESCRIPTION
This patch renames the higher-order stream `Limit` to `Head`. It is a reaction to the upcoming https://github.com/jplatte/eyeball/pull/69 where I've initially proposed the name `RLimit`. After a short thinking, I believe renaming `Limit` to `Head` and `RLimit` to `Tail` would be better names.

This patch renames `Limit` to `Head`.