### PR TITLE
Update and patch `imbl` dep to fix their bug in `Focus::narrow()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,19 @@ keywords = ["async", "observable", "reactive"]
 assert_matches = "1.5.0"
 futures-core = "0.3.26"
 futures-util = { version = "0.3.26", default-features = false }
+imbl = "4.0.0"
 readlock = "0.1.5"
 stream_assert = "0.1.0"
 tokio = { version = "1.25.0", features = ["sync"] }
 tokio-util = "0.7.8"
 tracing = { version = "0.1.37", default-features = false, features = ["std"] }
+
+
+[patch.crates-io]
+# Needed to fix an incorrect bounds check in `imbl::Focus::narrow()`. 
+# Can be removed once a new version of imbl is released with this fix included.
+imbl = { git = "https://github.com/jneem/imbl", rev = "7c5f24099c62c9f8d5d949bb79725c91251b78fb" }
+
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }

--- a/eyeball-im-util/Cargo.toml
+++ b/eyeball-im-util/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 arrayvec = "0.7.4"
 eyeball-im = { version = "0.5.1", path = "../eyeball-im" }
 futures-core.workspace = true
-imbl = "3.0.0"
+imbl.workspace = true
 pin-project-lite = "0.2.9"
 smallvec = { version = "1.11.2", features = ["const_generics", "const_new"] }
 

--- a/eyeball-im/Cargo.toml
+++ b/eyeball-im/Cargo.toml
@@ -14,7 +14,7 @@ all-features = true
 
 [dependencies]
 futures-core.workspace = true
-imbl = "3.0.0"
+imbl.workspace = true
 serde = { version = "1.0", optional = true }
 tokio.workspace = true
 tracing = { workspace = true, optional = true }


### PR DESCRIPTION
Update the `imbl` dependency to include this recent fix specifically: https://github.com/jneem/imbl/pull/89

This is causing bugs in the matrix-rust-sdk and in downstream clients, e.g., https://github.com/project-robius/robrix/pull/332

Once this is merged in, I will similarly patch the `matrix-rust-sdk` such that clients can leverage the fix too.