### PR TITLE
feat: Add the `Skip` higher-order stream

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+skeep = "skeep"

--- a/eyeball-im-util/src/vector.rs
+++ b/eyeball-im-util/src/vector.rs
@@ -3,6 +3,7 @@
 mod filter;
 mod head;
 mod ops;
+mod skip;
 mod sort;
 mod tail;
 mod traits;
@@ -14,6 +15,7 @@ use self::ops::{VectorDiffContainerFamilyMember, VectorDiffContainerOps};
 pub use self::{
     filter::{Filter, FilterMap},
     head::{EmptyLimitStream, Head},
+    skip::{EmptyCountStream, Skip},
     sort::{Sort, SortBy, SortByKey},
     tail::Tail,
     traits::{
@@ -51,6 +53,11 @@ type VectorDiffContainerStreamHeadBuf<S> =
 /// [`VectorDiffContainer`]s' `TailBuf`.
 type VectorDiffContainerStreamTailBuf<S> =
     <<S as Stream>::Item as VectorDiffContainerOps<VectorDiffContainerStreamElement<S>>>::TailBuf;
+
+/// Type alias for extracting the buffer type from a stream of
+/// [`VectorDiffContainer`]s' `SkipBuf`.
+type VectorDiffContainerStreamSkipBuf<S> =
+    <<S as Stream>::Item as VectorDiffContainerOps<VectorDiffContainerStreamElement<S>>>::SkipBuf;
 
 /// Type alias for extracting the buffer type from a stream of
 /// [`VectorDiffContainer`]s' `SortBuf`.

--- a/eyeball-im-util/src/vector/skip.rs
+++ b/eyeball-im-util/src/vector/skip.rs
@@ -1,0 +1,561 @@
+use smallvec::SmallVec;
+use std::{
+    cmp::{min, Ordering},
+    iter::repeat,
+    pin::Pin,
+    task::{self, ready, Poll},
+};
+
+use super::{
+    VectorDiffContainer, VectorDiffContainerOps, VectorDiffContainerStreamElement,
+    VectorDiffContainerStreamSkipBuf, VectorObserver,
+};
+use eyeball_im::VectorDiff;
+use futures_core::Stream;
+use imbl::Vector;
+use pin_project_lite::pin_project;
+
+pin_project! {
+    /// A [`VectorDiff`] stream adapter that presents a limited view of the
+    /// underlying [`ObservableVector`]s items. The view starts after `count`
+    /// number of values are skipped, until the end. It must not be confused
+    /// with [`Tail`](super::Tail) where `Tail` keeps the last values, while
+    /// `Skip` skips the first values.
+    ///
+    /// For example, let `S` be a `Stream<Item = VectorDiff>`. The [`Vector`]
+    /// represented by `S` can have any length, but one may want to virtually
+    /// skip the first `count` values. Then this `Skip` adapter is appropriate.
+    ///
+    /// An internal buffered vector is kept so that the adapter knows which
+    /// values can be added when the index is decreased, or when values are
+    /// removed and new values must be inserted. This fact is important if the
+    /// items of the `Vector` have a non-negligible size.
+    ///
+    /// It's okay to have an index larger than the length of the observed
+    /// `Vector`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use eyeball_im::{ObservableVector, VectorDiff};
+    /// use eyeball_im_util::vector::VectorObserverExt;
+    /// use imbl::vector;
+    /// use stream_assert::{assert_closed, assert_next_eq, assert_pending};
+    ///
+    /// // Our vector.
+    /// let mut ob = ObservableVector::<char>::new();
+    /// let (values, mut sub) = ob.subscribe().skip(3);
+    ///
+    /// assert!(values.is_empty());
+    /// assert_pending!(sub);
+    ///
+    /// // Append multiple values.
+    /// ob.append(vector!['a', 'b', 'c', 'd', 'e']);
+    /// // We get a `VectorDiff::Append` with the latest 2 values because the
+    /// // first 3 values have been skipped!
+    /// assert_next_eq!(sub, VectorDiff::Append { values: vector!['d', 'e'] });
+    ///
+    /// // Let's recap what we have. `ob` is our `ObservableVector`,
+    /// // `sub` is the “limited view” of `ob`:
+    /// // | `ob`  | a b c d e |
+    /// // | `sub` | _ _ _ d e |
+    /// // “_” means the item has been skipped.
+    ///
+    /// // Append multiple values.
+    /// ob.append(vector!['f', 'g']);
+    /// // We get a single `VectorDiff`.
+    /// assert_next_eq!(sub, VectorDiff::Append { values: vector!['f', 'g'] });
+    ///
+    /// // Let's recap what we have:
+    /// // | `ob`  | a b c d e f g |
+    /// // | `sub` | _ _ _ d e f g |
+    /// //                     ^^^
+    /// //                     |
+    /// //                     `VectorDiff::Append { .. }`
+    ///
+    /// // Insert a single value.
+    /// ob.insert(1, 'h');
+    /// // We get a single `VectorDiff::PushFront`. Indeed, `h` is inserted at
+    /// // index 1, so every value after that is shifted to the right, thus `c`
+    /// // “enters the view” via a `PushFront`.
+    /// assert_next_eq!(sub, VectorDiff::PushFront { value: 'c' });
+    ///
+    /// // Let's recap what we have:
+    /// // | `ob`  | a h b c d e f g |
+    /// // | `sub` | _ _ _ c d e f g |
+    /// //                 ^
+    /// //                 |
+    /// //                 `VectorDiff::PushFront { .. }`
+    ///
+    /// assert_pending!(sub);
+    /// drop(ob);
+    /// assert_closed!(sub);
+    /// ```
+    ///
+    /// [`ObservableVector`]: eyeball_im::ObservableVector
+    #[project = SkipProj]
+    pub struct Skip<S, C>
+    where
+        S: Stream,
+        S::Item: VectorDiffContainer,
+    {
+        // The main stream to poll items from.
+        #[pin]
+        inner_stream: S,
+
+        // The count stream to poll new count values from.
+        #[pin]
+        count_stream: C,
+
+        // The buffered vector that is updated with the main stream's items.
+        // It's used to provide missing items, e.g. when the count decreases or
+        // when values must be filled.
+        buffered_vector: Vector<VectorDiffContainerStreamElement<S>>,
+
+        // The current count.
+        //
+        // This is an option because it can be uninitialized. It's incorrect
+        // to use a default value for `count`, contrary to [`Head`] or [`Tail`]
+        // where `limit` can be 0.
+        count: Option<usize>,
+
+        // This adapter is not a basic filter: It can produce many items per
+        // item of the underlying stream.
+        //
+        // Thus, if the item type is just `VectorDiff<_>` (non-bached, can't
+        // just add diffs to a poll_next result), we need a buffer to store the
+        // possible extra item in.
+        ready_values: VectorDiffContainerStreamSkipBuf<S>,
+    }
+}
+
+impl<S> Skip<S, EmptyCountStream>
+where
+    S: Stream,
+    S::Item: VectorDiffContainer,
+{
+    /// Create a new [`Skip`] with the given (unlimited) initial values,
+    /// stream of `VectorDiff` updates for those values, and a fixed count.
+    ///
+    /// Returns the initial values as well as a stream of updates that ensure
+    /// that the resulting vector never includes the first `count` items.
+    pub fn new(
+        initial_values: Vector<VectorDiffContainerStreamElement<S>>,
+        inner_stream: S,
+        count: usize,
+    ) -> (Vector<VectorDiffContainerStreamElement<S>>, Self) {
+        Self::dynamic_with_initial_count(initial_values, inner_stream, count, EmptyCountStream)
+    }
+}
+
+impl<S, C> Skip<S, C>
+where
+    S: Stream,
+    S::Item: VectorDiffContainer,
+    C: Stream<Item = usize>,
+{
+    /// Create a new [`Skip`] with the given (unlimited) initial values,
+    /// stream of `VectorDiff` updates for those values, and a stream of
+    /// indices.
+    ///
+    /// This is equivalent to `dynamic_with_initial_count` where the
+    /// `initial_count` is `usize::MAX`, except that it doesn't return the
+    /// limited vector as it would be empty anyways.
+    ///
+    /// Note that the returned `Skip` won't produce anything until the first
+    /// count is produced by the index stream.
+    pub fn dynamic(
+        initial_values: Vector<VectorDiffContainerStreamElement<S>>,
+        inner_stream: S,
+        count_stream: C,
+    ) -> Self {
+        Self {
+            inner_stream,
+            count_stream,
+            buffered_vector: initial_values,
+            count: None,
+            ready_values: Default::default(),
+        }
+    }
+
+    /// Create a new [`Skip`] with the given (unlimited) initial values,
+    /// stream of `VectorDiff` updates for those values, and an initial
+    /// count as well as a stream of new count values.
+    pub fn dynamic_with_initial_count(
+        initial_values: Vector<VectorDiffContainerStreamElement<S>>,
+        inner_stream: S,
+        initial_count: usize,
+        count_stream: C,
+    ) -> (Vector<VectorDiffContainerStreamElement<S>>, Self) {
+        let buffered_vector = initial_values.clone();
+
+        let initial_values = initial_values.skeep(initial_count);
+
+        let stream = Self {
+            inner_stream,
+            count_stream,
+            buffered_vector,
+            count: Some(initial_count),
+            ready_values: Default::default(),
+        };
+
+        (initial_values, stream)
+    }
+}
+
+impl<S, C> Stream for Skip<S, C>
+where
+    S: Stream,
+    S::Item: VectorDiffContainer,
+    C: Stream<Item = usize>,
+{
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project().poll_next(cx)
+    }
+}
+
+impl<S, C> VectorObserver<VectorDiffContainerStreamElement<S>> for Skip<S, C>
+where
+    S: Stream,
+    S::Item: VectorDiffContainer,
+    C: Stream<Item = usize>,
+{
+    type Stream = Self;
+
+    fn into_parts(self) -> (Vector<VectorDiffContainerStreamElement<S>>, Self::Stream) {
+        (self.buffered_vector.clone(), self)
+    }
+}
+
+impl<S, C> SkipProj<'_, S, C>
+where
+    S: Stream,
+    S::Item: VectorDiffContainer,
+    C: Stream<Item = usize>,
+{
+    fn poll_next(&mut self, cx: &mut task::Context<'_>) -> Poll<Option<S::Item>> {
+        loop {
+            // First off, if any values are ready, return them.
+            if let Some(value) = S::Item::pop_from_skip_buf(self.ready_values) {
+                return Poll::Ready(Some(value));
+            }
+
+            // Poll a new count value from `count_stream` before polling `inner_stream`.
+            while let Poll::Ready(Some(next_count)) = self.count_stream.as_mut().poll_next(cx) {
+                // Update the count value and emit `VectorDiff`s accordingly.
+                if let Some(diffs) = self.update_count(next_count) {
+                    return Poll::Ready(S::Item::extend_skip_buf(diffs, self.ready_values));
+                }
+
+                // If `update_count` returned `None`, poll the count stream
+                // again.
+            }
+
+            // Poll `VectorDiff`s from the `inner_stream`.
+            let Some(diffs) = ready!(self.inner_stream.as_mut().poll_next(cx)) else {
+                return Poll::Ready(None);
+            };
+
+            // Consume and apply the diffs if possible.
+            let ready = diffs.push_into_skip_buf(self.ready_values, |diff| {
+                let count = *self.count;
+                let previous_length = self.buffered_vector.len();
+
+                // Update the `buffered_vector`. It's a replica of the original observed
+                // `Vector`. We need to maintain it in order to be able to produce valid
+                // `VectorDiff`s when items are missing.
+                diff.clone().apply(self.buffered_vector);
+
+                // Handle the `diff` if and only if there is a count.
+                if let Some(count) = count {
+                    handle_diff(diff, count, previous_length, self.buffered_vector)
+                } else {
+                    SmallVec::new()
+                }
+            });
+
+            if let Some(diff) = ready {
+                return Poll::Ready(Some(diff));
+            }
+
+            // Else loop and poll the streams again.
+        }
+    }
+
+    /// Update the count value if necessary.
+    ///
+    /// * If the buffered vector is empty, it returns `None`.
+    /// * If the count decreases, `VectorDiff::PushFront`s are produced if any
+    ///   items exist.
+    /// * If the count increases, `VectorDiff::PopFront`s are produced.
+    ///
+    /// It's OK to have a `new_count` larger than the length of the `Vector`.
+    /// The `new_count` won't be capped.
+    fn update_count(
+        &mut self,
+        new_count: usize,
+    ) -> Option<Vec<VectorDiff<VectorDiffContainerStreamElement<S>>>> {
+        // Let's update the count.
+        let old_count = self.count.replace(new_count);
+
+        if self.buffered_vector.is_empty() {
+            // If empty, nothing to do.
+            return None;
+        }
+
+        let old_count = match old_count {
+            // First time `count` is initialized.
+            None => {
+                return Some(vec![VectorDiff::Append {
+                    values: self.buffered_vector.clone().skeep(new_count),
+                }])
+            }
+
+            // Other updates of `count`.
+            Some(old_count) => old_count,
+        };
+
+        // Clamp `old_count` and `new_count` to the length of `buffered_vector` in case
+        // it is larger.
+        let buffered_vector_length = self.buffered_vector.len();
+        let old_count = min(old_count, buffered_vector_length);
+        let new_count = min(new_count, buffered_vector_length);
+
+        match old_count.cmp(&new_count) {
+            // old < new, count is shifting to the right
+            Ordering::Less => {
+                // Skip more items than the buffer contains: we must clear all existing items.
+                if buffered_vector_length <= new_count {
+                    Some(vec![VectorDiff::Clear])
+                } else {
+                    // Let's remove the extra items.
+                    Some(repeat(VectorDiff::PopFront).take(new_count - old_count).collect())
+                }
+            }
+
+            // old > new, count is shifting to the left
+            Ordering::Greater => {
+                // Optimisation: when `old_count` is at the end of `buffered_vector`, and
+                // `new_count` is zero, we can emit a single `VectorDiff::Append` instead of
+                // many `VectorDiff::PushFront`.
+                if old_count == buffered_vector_length && new_count == 0 {
+                    Some(vec![VectorDiff::Append { values: self.buffered_vector.clone() }])
+                } else {
+                    let mut missing_items = self
+                        .buffered_vector
+                        .iter()
+                        .rev()
+                        .skip(buffered_vector_length - old_count)
+                        .take(old_count - new_count)
+                        .cloned()
+                        .peekable();
+
+                    if missing_items.peek().is_none() {
+                        None
+                    } else {
+                        // Let's add the missing items.
+                        Some(
+                            missing_items
+                                .map(|missing_item| VectorDiff::PushFront { value: missing_item })
+                                .collect(),
+                        )
+                    }
+                }
+            }
+
+            // old == new
+            Ordering::Equal => {
+                // Nothing to do.
+                None
+            }
+        }
+    }
+}
+
+fn handle_diff<T: Clone>(
+    diff: VectorDiff<T>,
+    count: usize,
+    previous_length: usize,
+    buffered_vector: &Vector<T>,
+) -> SmallVec<[VectorDiff<T>; 2]> {
+    let mut res = SmallVec::new();
+
+    match diff {
+        VectorDiff::Append { values } => {
+            // Some values are appended after `count`.
+            if buffered_vector.len() > count {
+                // Cut `values` if they aren't all appended after `count`.
+                //
+                // Note: Do a `<` instead of `<=` to avoid calling `skip` with 0.
+
+                let values = if previous_length < count {
+                    values.skeep(count - previous_length)
+                } else {
+                    values
+                };
+
+                res.push(VectorDiff::Append { values });
+            }
+        }
+
+        VectorDiff::Clear => {
+            res.push(VectorDiff::Clear);
+        }
+
+        VectorDiff::PushFront { value } => {
+            // The push shifts values after `count`.
+            if previous_length >= count {
+                // The value at `count` is the one that must be pushed front.
+                //
+                // If `count` is zero, let's avoid a look up + clone by forwarding `value`.
+                // Otherwise, let's look up at `count`.
+                if count == 0 {
+                    res.push(VectorDiff::PushFront { value });
+                } else if let Some(value) = buffered_vector.get(count) {
+                    res.push(VectorDiff::PushFront { value: value.clone() });
+                }
+            }
+        }
+
+        VectorDiff::PushBack { value } => {
+            // The push happens after `count`.
+            if previous_length >= count {
+                res.push(VectorDiff::PushBack { value });
+            }
+        }
+
+        VectorDiff::PopFront => {
+            // The pop shifts values after `count`.
+            if previous_length > count {
+                res.push(VectorDiff::PopFront);
+            }
+        }
+
+        VectorDiff::PopBack => {
+            // The pop happens after `count`.
+            if previous_length > count {
+                res.push(VectorDiff::PopBack);
+            }
+        }
+
+        VectorDiff::Insert { index, value } => {
+            // The insert shifts values after `count`.
+            if previous_length >= count {
+                // The insert happens before `count`, we need to insert a new
+                // value with `PushFront`.
+                if count > 0 && index < count {
+                    // The value at `count` is the one that must be
+                    // pushed front.
+                    if let Some(value) = buffered_vector.get(count) {
+                        res.push(VectorDiff::PushFront { value: value.clone() });
+                    }
+                }
+                // The insert happens after `count`, we need to re-map `index`.
+                else {
+                    res.push(VectorDiff::Insert { index: index - count, value });
+                }
+            }
+        }
+
+        VectorDiff::Set { index, value } => {
+            // The update happens after `count`.
+            if index >= count {
+                res.push(VectorDiff::Set { index: index - count, value });
+            }
+        }
+
+        VectorDiff::Remove { index } => {
+            // The removal happens inside the view.
+            if previous_length > count {
+                // The removal happens before `count`, we need to pop a value at
+                // the front.
+                if index < count {
+                    res.push(VectorDiff::PopFront);
+                }
+                // The removal happens after `count`, we need to re-map `index`.
+                else {
+                    res.push(VectorDiff::Remove { index: index - count });
+                }
+            }
+        }
+
+        VectorDiff::Truncate { length: new_length } => {
+            // The truncation removes some values after `count`.
+            if previous_length > count {
+                // All values removed by the truncation are after `count`.
+                if new_length > count {
+                    res.push(VectorDiff::Truncate { length: new_length - count });
+                }
+                // Some values removed by the truncation are before `count` or exactly at `count`.
+                // It means that all values must be cleared.
+                else {
+                    res.push(VectorDiff::Clear);
+                }
+            }
+        }
+
+        VectorDiff::Reset { values } => {
+            res.push(VectorDiff::Reset { values: values.skeep(count) });
+        }
+    }
+
+    res
+}
+
+/// An empty stream with an item type of `usize`.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct EmptyCountStream;
+
+impl Stream for EmptyCountStream {
+    type Item = usize;
+
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Ready(None)
+    }
+}
+
+trait Skeep {
+    fn skeep(self, count: usize) -> Self;
+}
+
+impl<T> Skeep for Vector<T>
+where
+    T: Clone,
+{
+    fn skeep(self, count: usize) -> Self {
+        match count {
+            // Skip 0 values, let's return all of them.
+            0 => self,
+
+            // Skip more values than `self` contains, let's return an empty `Vector`.
+            count if count >= self.len() => Vector::new(),
+
+            // Skip the first n values.
+            count => self.skip(count),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Skeep;
+    use imbl::vector;
+
+    #[test]
+    fn test_skeep() {
+        // Count is 0.
+        assert_eq!(vector![1, 2, 3, 4].skeep(0), vector![1, 2, 3, 4]);
+
+        // Count is smaller than the values.
+        assert_eq!(vector![1, 2, 3, 4].skeep(2), vector![3, 4]);
+
+        // Count is equal to the number of values.
+        assert_eq!(vector![1, 2, 3, 4].skeep(4), vector![]);
+
+        // Count is larger than the number of values.
+        assert_eq!(vector![1, 2, 3, 4].skeep(6), vector![]);
+    }
+}

--- a/eyeball-im-util/src/vector/traits.rs
+++ b/eyeball-im-util/src/vector/traits.rs
@@ -12,7 +12,8 @@ use super::{
     ops::{
         VecVectorDiffFamily, VectorDiffContainerFamily, VectorDiffContainerOps, VectorDiffFamily,
     },
-    EmptyLimitStream, Filter, FilterMap, Head, Sort, SortBy, SortByKey, Tail,
+    EmptyCountStream, EmptyLimitStream, Filter, FilterMap, Head, Skip, Sort, SortBy, SortByKey,
+    Tail,
 };
 
 /// Abstraction over stream items that the adapters in this module can deal
@@ -194,6 +195,42 @@ where
     {
         let (items, stream) = self.into_parts();
         Tail::dynamic_with_initial_limit(items, stream, initial_limit, limit_stream)
+    }
+
+    /// Skip the first `count` observed values.
+    ///
+    /// See [`Skip`] for more details.
+    fn skip(self, count: usize) -> (Vector<T>, Skip<Self::Stream, EmptyCountStream>) {
+        let (items, stream) = self.into_parts();
+        Skip::new(items, stream, count)
+    }
+
+    /// Skip the first `count` observed values, where `count` is determined by
+    /// the given stream.
+    ///
+    /// See [`Skip`] for more details.
+    fn dynamic_skip<C>(self, count_stream: C) -> Skip<Self::Stream, C>
+    where
+        C: Stream<Item = usize>,
+    {
+        let (items, stream) = self.into_parts();
+        Skip::dynamic(items, stream, count_stream)
+    }
+
+    /// Skip the first `initial_count` observed values, and update the `count`
+    /// with the values from the given stream.
+    ///
+    /// See [`Skip`] for more details.
+    fn dynamic_skip_with_initial_count<C>(
+        self,
+        initial_count: usize,
+        count_stream: C,
+    ) -> (Vector<T>, Skip<Self::Stream, C>)
+    where
+        C: Stream<Item = usize>,
+    {
+        let (items, stream) = self.into_parts();
+        Skip::dynamic_with_initial_count(items, stream, initial_count, count_stream)
     }
 
     /// Sort the observed values.

--- a/eyeball-im-util/tests/it/main.rs
+++ b/eyeball-im-util/tests/it/main.rs
@@ -3,6 +3,7 @@
 mod filter;
 mod filter_map;
 mod head;
+mod skip;
 mod sort;
 mod sort_by;
 mod sort_by_key;

--- a/eyeball-im-util/tests/it/skip.rs
+++ b/eyeball-im-util/tests/it/skip.rs
@@ -1,0 +1,1118 @@
+use eyeball::Observable;
+use eyeball_im::{ObservableVector, VectorDiff};
+use eyeball_im_util::vector::VectorObserverExt;
+use imbl::vector;
+use stream_assert::{assert_closed, assert_next_eq, assert_pending};
+
+#[test]
+fn static_count() {
+    let mut ob: ObservableVector<usize> = ObservableVector::from(vector![10, 11, 12, 13]);
+    let (initial_values, mut sub) = ob.subscribe().skip(2);
+    assert_eq!(initial_values, vector![12, 13]);
+    assert_pending!(sub);
+
+    // 10 is removed, it shifts values and 12 is removed.
+    ob.pop_front();
+    assert_next_eq!(sub, VectorDiff::PopFront);
+
+    // 14 is added at the back.
+    ob.push_back(14);
+    assert_next_eq!(sub, VectorDiff::PushBack { value: 14 });
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn pending_until_count_emits_a_value() {
+    let mut ob: ObservableVector<usize> = ObservableVector::new();
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    // Append new values…
+    ob.append(vector![10, 11, 12, 13, 14, 15]);
+
+    // … but it's still pending…
+    assert_pending!(sub);
+
+    // … because the `count` stream didn't produce any value yet.
+    // Let's change that.
+    Observable::set(&mut count, 3);
+
+    // Here we are.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![13, 14, 15] });
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn update_count_before_polling_sub() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    // Append 4 values.
+    ob.append(vector![10, 11, 12, 13]);
+
+    // Observe nothing because the count is still undefined.
+    assert_pending!(sub);
+
+    // Set count to 2.
+    Observable::set(&mut count, 2);
+
+    // Observe 2 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![12, 13] });
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn update_count_after_polling_sub() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    // Append 4 values.
+    ob.append(vector![10, 11, 12, 13]);
+
+    // Set count to 2.
+    Observable::set(&mut count, 2);
+
+    // Observe 2 values.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![12, 13] });
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn increase_and_decrease_the_count_on_an_empty_stream() {
+    let ob = ObservableVector::<usize>::new();
+    let mut count = Observable::new(1);
+    let (initial_values, mut sub) =
+        ob.subscribe().dynamic_skip_with_initial_count(1, Observable::subscribe(&count));
+
+    assert!(initial_values.is_empty());
+
+    // `ob` is empty!
+
+    // Set count to 2.
+    Observable::set(&mut count, 2);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    // Set count to 1.
+    Observable::set(&mut count, 1);
+
+    // Observe nothing.
+    assert_pending!(sub);
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn increase_and_decrease_the_count_only() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    // Append 4 values.
+    ob.append(vector![10, 11, 12, 13, 14]);
+
+    // Observe nothing because the count is still undefined.
+    assert_pending!(sub);
+
+    // Set `count` to its first value.
+    Observable::set(&mut count, 2);
+
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![12, 13, 14] });
+
+    // Set `count` closer to the length of the vector.
+    Observable::set(&mut count, 4);
+
+    assert_next_eq!(sub, VectorDiff::PopFront);
+    assert_next_eq!(sub, VectorDiff::PopFront);
+
+    // Set `count` to the length of the vector.
+    Observable::set(&mut count, 5);
+
+    // Optimisation: A `Clear` is emitted instead of many `PopFront`.
+    assert_next_eq!(sub, VectorDiff::Clear);
+
+    // Set `count` out of bounds.
+    Observable::set(&mut count, 7);
+
+    assert_pending!(sub);
+
+    // Set `count` back to the length of the vector.
+    Observable::set(&mut count, 5);
+
+    assert_pending!(sub);
+
+    // Set `count` to 2.
+    Observable::set(&mut count, 2);
+
+    assert_next_eq!(sub, VectorDiff::PushFront { value: 14 });
+    assert_next_eq!(sub, VectorDiff::PushFront { value: 13 });
+    assert_next_eq!(sub, VectorDiff::PushFront { value: 12 });
+
+    // Set `count` to 0.
+    Observable::set(&mut count, 0);
+
+    assert_next_eq!(sub, VectorDiff::PushFront { value: 11 });
+    assert_next_eq!(sub, VectorDiff::PushFront { value: 10 });
+
+    // Set `count` to 3.
+    Observable::set(&mut count, 3);
+
+    assert_next_eq!(sub, VectorDiff::PopFront);
+    assert_next_eq!(sub, VectorDiff::PopFront);
+    assert_next_eq!(sub, VectorDiff::PopFront);
+
+    // Enough fun.
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn count_at_limits() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    // Append 4 values.
+    ob.append(vector![10, 11, 12, 13]);
+
+    // Set `count` to 10.
+    Observable::set(&mut count, 10);
+
+    assert_pending!(sub);
+
+    // Add 1 value.
+    ob.push_back(14);
+
+    assert_pending!(sub);
+
+    // Set `count` to 0.
+    Observable::set(&mut count, 0);
+
+    // Optimisation: a single `Append` is generated instead of 5 `PushFront`.
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![10, 11, 12, 13, 14] });
+
+    // Set `count` to 10 again.
+    Observable::set(&mut count, 10);
+
+    assert_next_eq!(sub, VectorDiff::Clear);
+
+    // Add 1 value.
+    ob.push_back(15);
+
+    assert_pending!(sub);
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn count_is_polled_first() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    // Append 4 values.
+    ob.append(vector![10, 11, 12, 13]);
+
+    // Set `count` to 3.
+    Observable::set(&mut count, 3);
+
+    assert_next_eq!(sub, VectorDiff::Append { values: vector![13] });
+
+    // Add 1 value on the back…
+    ob.push_back(14);
+
+    // … and set `count` to 2 _after_.
+    Observable::set(&mut count, 2);
+
+    // However, let's observe the `count`'s change _first_…
+    assert_next_eq!(sub, VectorDiff::PushFront { value: 12 });
+
+    // … and let's observe the other updates _after_.
+    assert_next_eq!(sub, VectorDiff::PushBack { value: 14 });
+    assert_pending!(sub);
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn append() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    // We need to test appending values:
+    //
+    // - before `count` where not a single value reaches `count` (test case #1),
+    // - before `count` where some values are outreaching `count` (test case #2),
+    // - after `count` (test case #3).
+
+    Observable::set(&mut count, 6);
+
+    // Test case #1.
+    //
+    // Count is not reached; append values; no value reaches `count`.
+    {
+        ob.append(vector![10, 11, 12, 13]);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13 ]
+        // - the “view”: [  X   X   X   X ]
+    }
+
+    // Test case #2.
+    //
+    // Count is not reached; append values; some values are outreaching `count`.
+    {
+        ob.append(vector![14, 15, 16, 17]);
+
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![16, 17] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15, 16, 17 ]
+        // - the “view”: [  X   X   X   X   X   X, 16, 17 ]
+    }
+
+    // Test case #3.
+    //
+    // Count is reached; append values.
+    {
+        ob.append(vector![18, 19, 20]);
+
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![18, 19, 20] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 ]
+        // - the “view”: [  X   X   X   X   X   X, 16, 17, 18, 19, 20 ]
+    }
+
+    assert_pending!(sub);
+
+    // Check the content of the vector.
+    {
+        let expected = vector![10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut count, 128);
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        Observable::set(&mut count, 0);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn clear() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    // Set `count` to 4.
+    Observable::set(&mut count, 4);
+
+    // Add 1 value.
+    ob.push_back(10);
+
+    // Clear.
+    ob.clear();
+
+    // Observe a single update (the push back is skipped).
+    assert_next_eq!(sub, VectorDiff::Clear);
+
+    // Check the content of the vector.
+    {
+        let expected = vector![];
+        assert_eq!(*ob, expected);
+    }
+
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn push_front() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    // Set `count` to 2.
+    Observable::set(&mut count, 2);
+
+    // Vector is empty and `count` is polled for the first time.
+    {
+        ob.push_front(10);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 10 ]
+        // - the “view”: [  X ]
+    }
+
+    // Push front, the `count` is not reached yet.
+    {
+        ob.push_front(11);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 11, 10 ]
+        // - the “view”: [  X,  X ]
+    }
+
+    // Push front, the `count` is reached.
+    {
+        ob.push_front(12);
+
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 10 })
+
+        // State of:
+        //
+        // - the vector: [ 12, 11, 10 ]
+        // - the “view”: [  X,  X, 10 ]
+    }
+
+    // Push front, the `count` is outreached.
+    {
+        ob.push_front(13);
+
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 11 })
+
+        // State of:
+        //
+        // - the vector: [ 13, 12, 11, 10 ]
+        // - the “view”: [  X,  X, 11, 10 ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![13, 12, 11, 10];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut count, 128);
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        Observable::set(&mut count, 0);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn push_back() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    // Set `count` to 2.
+    Observable::set(&mut count, 2);
+
+    // Vector is empty and `count` is polled for the first time.
+    {
+        ob.push_back(10);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 10 ]
+        // - the “view”: [  X ]
+    }
+
+    // Push back, the `count` is not reached yet.
+    {
+        ob.push_back(11);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 10, 11 ]
+        // - the “view”: [  X,  X ]
+    }
+
+    // Push back, the `count` is reached.
+    {
+        ob.push_back(12);
+
+        assert_next_eq!(sub, VectorDiff::PushBack { value: 12 })
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12 ]
+        // - the “view”: [  X,  X, 12 ]
+    }
+
+    // Push back, the `count` is outreached.
+    {
+        ob.push_back(13);
+
+        assert_next_eq!(sub, VectorDiff::PushBack { value: 13 })
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13 ]
+        // - the “view”: [  X,  X, 12, 13 ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![10, 11, 12, 13];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut count, 128);
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        Observable::set(&mut count, 0);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn pop_front() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    // Init state.
+    {
+        ob.append(vector![10, 11, 12, 13]);
+        Observable::set(&mut count, 2);
+
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![12, 13] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13 ]
+        // - the “view”: [  X,  X, 12, 13 ]
+    }
+
+    // Pop front, it shifts values before, and thus after `count`.
+    {
+        ob.pop_front(); // 10
+
+        assert_next_eq!(sub, VectorDiff::PopFront); // 12
+
+        // State of:
+        //
+        // - the vector: [ 11, 12, 13 ]
+        // - the “view”: [  X,  X, 13 ]
+    }
+
+    // Pop front, it shifts values before, and thus after `count`.
+    {
+        ob.pop_front(); // 11
+
+        assert_next_eq!(sub, VectorDiff::PopFront); // 13
+
+        // State of:
+        //
+        // - the vector: [ 12, 13 ]
+        // - the “view”: [  X,  X ]
+    }
+
+    // Pop front, it shifts values before `count`.
+    {
+        ob.pop_front(); // 12
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 13 ]
+        // - the “view”: [  X ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![13];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut count, 128);
+        assert_pending!(sub);
+
+        Observable::set(&mut count, 0);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn pop_back() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    // Init state.
+    {
+        ob.append(vector![10, 11, 12, 13]);
+        Observable::set(&mut count, 2);
+
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![12, 13] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13 ]
+        // - the “view”: [  X,  X, 12, 13 ]
+    }
+
+    // Pop back, it happens after `count`.
+    {
+        ob.pop_back(); // 13
+
+        assert_next_eq!(sub, VectorDiff::PopBack);
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12 ]
+        // - the “view”: [  X,  X, 12 ]
+    }
+
+    // Pop back, it happens after `count`.
+    {
+        ob.pop_back(); // 12
+
+        assert_next_eq!(sub, VectorDiff::PopBack);
+
+        // State of:
+        //
+        // - the vector: [ 10, 11 ]
+        // - the “view”: [  X,  X ]
+    }
+
+    // Pop back, it happens before `count`.
+    {
+        ob.pop_back(); // 11
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 10 ]
+        // - the “view”: [  X ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![10];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut count, 128);
+        assert_pending!(sub);
+
+        Observable::set(&mut count, 0);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn insert() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    Observable::set(&mut count, 2);
+
+    // Insert at 0, on an empty vector.
+    {
+        ob.insert(0, 10);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 10 ]
+        // - the “view”: [  X ]
+    }
+
+    // Insert at 0, on a non-empty vector, still inside the view.
+    {
+        ob.insert(0, 11);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 11, 10 ]
+        // - the “view”: [  X,  X ]
+    }
+
+    // Insert at 0, on a non-empty vector, but this time, `count` is reached.
+    {
+        ob.insert(0, 12);
+
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 10 });
+
+        // State of:
+        //
+        // - the vector: [ 12, 11, 10 ]
+        // - the “view”: [  X,  X, 10 ]
+    }
+
+    // Insert just before `count`.
+    {
+        ob.insert(1, 13);
+
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 11 });
+
+        // State of:
+        //
+        // - the vector: [ 12, 13, 11, 10 ]
+        // - the “view”: [  X,  X, 11, 10 ]
+    }
+
+    // Insert at `count`.
+    {
+        ob.insert(2, 14);
+
+        assert_next_eq!(sub, VectorDiff::Insert { index: 0, value: 14 });
+
+        // State of:
+        //
+        // - the vector: [ 12, 13, 14, 11, 10 ]
+        // - the “view”: [  X,  X, 14, 11, 10 ]
+    }
+
+    // Insert after `count`.
+    {
+        ob.insert(3, 15);
+
+        assert_next_eq!(sub, VectorDiff::Insert { index: 1, value: 15 });
+
+        // State of:
+        //
+        // - the vector: [ 12, 13, 14, 15, 11, 10 ]
+        // - the “view”: [  X,  X, 14, 15, 11, 10 ]
+    }
+
+    // Insert at the end of the vector, after `count`.
+    {
+        ob.insert(6, 16);
+
+        assert_next_eq!(sub, VectorDiff::Insert { index: 4, value: 16 });
+
+        // State of:
+        //
+        // - the vector: [ 12, 13, 14, 15, 11, 10, 16 ]
+        // - the “view”: [  X,  X, 14, 15, 11, 10, 16 ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![12, 13, 14, 15, 11, 10, 16];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut count, 128);
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        Observable::set(&mut count, 0);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn set() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    // Init state.
+    {
+        ob.append(vector![10, 11, 12, 13]);
+        Observable::set(&mut count, 2);
+
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![12, 13] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13 ]
+        // - the “view”: [  X,  X, 12, 13 ]
+    }
+
+    // Set before `count`.
+    {
+        ob.set(0, 20);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 20, 11, 12, 13 ]
+        // - the “view”: [  X,  X, 12, 13 ]
+    }
+
+    // Set at `count`.
+    {
+        ob.set(2, 22);
+
+        assert_next_eq!(sub, VectorDiff::Set { index: 0, value: 22 });
+
+        // State of:
+        //
+        // - the vector: [ 20, 11, 22, 13 ]
+        // - the “view”: [  X,  X, 22, 13 ]
+    }
+
+    // Set after `count`.
+    {
+        ob.set(3, 23);
+
+        assert_next_eq!(sub, VectorDiff::Set { index: 1, value: 23 });
+
+        // State of:
+        //
+        // - the vector: [ 20, 11, 22, 23 ]
+        // - the “view”: [  X,  X, 22, 23 ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![20, 11, 22, 23];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut count, 128);
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        Observable::set(&mut count, 0);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn remove() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    // Init state.
+    {
+        ob.append(vector![10, 11, 12, 13, 14, 15]);
+        Observable::set(&mut count, 3);
+
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![13, 14, 15] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15 ]
+        // - the “view”: [  X,  X,  X, 13, 14, 15 ]
+    }
+
+    // There are 4 test cases:
+    //
+    // - remove before `count`, with no value after `count` (test case #1),
+    // - remove before `count`, with values after `count` (test case #2),
+    // - remove at `count` (test case #3),
+    // - remove after `count` (test case #4).
+
+    // Test case #2.
+    //
+    // Remove before `count`, values after `count`.
+    {
+        ob.remove(1);
+
+        assert_next_eq!(sub, VectorDiff::PopFront);
+
+        // State of:
+        //
+        // - the vector: [ 10, 12, 13, 14, 15 ]
+        // - the “view”: [  X,  X,  X, 14, 15 ]
+    }
+
+    // Test case #4.
+    //
+    // Remove after `count`.
+    {
+        ob.remove(4);
+
+        assert_next_eq!(sub, VectorDiff::Remove { index: 1 });
+
+        // State of:
+        //
+        // - the vector: [ 10, 12, 13, 14 ]
+        // - the “view”: [  X,  X,  X, 14 ]
+    }
+
+    // Test case #3.
+    //
+    // Remove at `count`.
+    {
+        ob.remove(3);
+
+        assert_next_eq!(sub, VectorDiff::Remove { index: 0 });
+
+        // State of:
+        //
+        // - the vector: [ 10, 12, 13 ]
+        // - the “view”: [  X,  X,  X ]
+    }
+
+    // Test case #1.
+    //
+    // Remove before `count`, no value after `count`.
+    {
+        ob.remove(1);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 10, 13 ]
+        // - the “view”: [  X,  X ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![10, 13];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut count, 128);
+        assert_pending!(sub);
+
+        Observable::set(&mut count, 0);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn truncate() {
+    let mut ob = ObservableVector::<usize>::new();
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    // Init state.
+    {
+        ob.append(vector![10, 11, 12, 13, 14, 15, 16, 17]);
+        Observable::set(&mut count, 5);
+
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![15, 16, 17] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15, 16, 17 ]
+        // - the “view”: [  X,  X,  X,  X,  X, 15, 16, 17 ]
+    }
+
+    // Truncate to a size larger than `count`.
+    {
+        ob.truncate(7);
+
+        assert_next_eq!(sub, VectorDiff::Truncate { length: 2 });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15, 16 ]
+        // - the “view”: [  X,  X,  X,  X,  X, 15, 16 ]
+    }
+
+    // Truncate to a size equal to `count`.
+    {
+        ob.truncate(5);
+
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14 ]
+        // - the “view”: [  X,  X,  X,  X,  X ]
+    }
+
+    // Truncate to a size smaller than `count` with values after `count`.
+    {
+        Observable::set(&mut count, 4);
+
+        assert_next_eq!(sub, VectorDiff::PushFront { value: 14 });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14 ]
+        // - the “view”: [  X,  X,  X,  X, 14 ]
+
+        ob.truncate(3);
+
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12 ]
+        // - the “view”: [  X,  X,  X ]
+    }
+
+    // Truncate to a size smaller than `count` with no values after `count`.
+    {
+        ob.truncate(2);
+
+        assert_pending!(sub);
+
+        // State of:
+        //
+        // - the vector: [ 10, 11 ]
+        // - the “view”: [  X,  X ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![10, 11];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut count, 128);
+        assert_pending!(sub);
+
+        Observable::set(&mut count, 0);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+#[test]
+fn reset() {
+    let mut ob = ObservableVector::<usize>::with_capacity(2);
+    let mut count = Observable::new(0);
+    let mut sub = ob.subscribe().dynamic_skip(Observable::subscribe(&count));
+
+    // Init state.
+    {
+        ob.append(vector![10, 11, 12, 13, 14, 15]);
+        Observable::set(&mut count, 3);
+
+        assert_next_eq!(sub, VectorDiff::Append { values: vector![13, 14, 15] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15 ]
+        // - the “view”: [  X,  X,  X, 13, 14, 15 ]
+    }
+
+    // Do multiple operations to saturate the observable capacity, in order to
+    // trigger a reset.
+    {
+        ob.push_back(16);
+        ob.push_back(17);
+        ob.push_back(18);
+    }
+
+    // Observe a reset, with skipped values.
+    {
+        assert_next_eq!(sub, VectorDiff::Reset { values: vector![13, 14, 15, 16, 17, 18] });
+
+        // State of:
+        //
+        // - the vector: [ 10, 11, 12, 13, 14, 15, 16, 17, 18 ]
+        // - the “view”: [  X,  X,  X, 13, 14, 15, 16, 17, 18 ]
+    }
+
+    // Check the content of the vector.
+    {
+        let expected = vector![10, 11, 12, 13, 14, 15, 16, 17, 18];
+        assert_eq!(*ob, expected);
+
+        Observable::set(&mut count, 128);
+        assert_next_eq!(sub, VectorDiff::Clear);
+
+        Observable::set(&mut count, 0);
+        assert_next_eq!(sub, VectorDiff::Append { values: expected });
+    }
+
+    assert_pending!(sub);
+    drop(ob);
+    assert_closed!(sub);
+}
+
+// This test is copied (and modified to match the behaviour of `Skip`) from
+// `Head`'s test suite. The bug is not present in `Skip`, but since their
+// behaviours are quite similar, let's ensure the bug cannot happen
+// preemptively.
+#[tokio::test]
+async fn count_stream_wake() {
+    use futures_util::{FutureExt, StreamExt};
+    use tokio::task::yield_now;
+
+    let ob = ObservableVector::<u32>::from(vector![1, 2, 3]);
+    let mut count = Observable::new(2);
+    let (values, mut sub) =
+        ob.subscribe().dynamic_skip_with_initial_count(2, Observable::subscribe(&count));
+
+    assert_eq!(values, vector![3]);
+
+    let task_hdl = tokio::spawn(async move {
+        let update = sub.next().await.unwrap();
+        assert_eq!(update, VectorDiff::PushFront { value: 2 });
+    });
+
+    // Set the `count` to the same value that `Skip` has already seen.
+    Observable::set(&mut count, 1);
+
+    // Make sure the task spawned above sees the "updated" count.
+    yield_now().await;
+
+    // Now update the `count` again.
+    Observable::set(&mut count, 2);
+
+    // Allow the task to make progress.
+    yield_now().await;
+
+    // It should be finished now.
+    task_hdl.now_or_never().unwrap().unwrap();
+}


### PR DESCRIPTION
This patch adds the `Skip` higher-order stream. Similarly to `Head` or `Tail`, it computes a limited view of the underlying `ObservableVector`'s items. The view starts after count number of values are skipped, until the end. It must not be confused with `Tail` where `Tail` keeps the last values, while `Skip` skips the first values.

```rust
use eyeball_im::{ObservableVector, VectorDiff};
use eyeball_im_util::vector::VectorObserverExt;
use imbl::vector;
use stream_assert::{assert_closed, assert_next_eq, assert_pending};

// Our vector.
let mut ob = ObservableVector::<char>::new();
let (values, mut sub) = ob.subscribe().skip(3);

assert!(values.is_empty());
assert_pending!(sub);

// Append multiple values.
ob.append(vector!['a', 'b', 'c', 'd', 'e']);
// We get a `VectorDiff::Append` with the latest 2 values because the
// first 3 values have been skipped!
assert_next_eq!(sub, VectorDiff::Append { values: vector!['d', 'e'] });

// Let's recap what we have. `ob` is our `ObservableVector`,
// `sub` is the “limited view” of `ob`:
// | `ob`  | a b c d e |
// | `sub` | _ _ _ d e |
// “_” means the item has been skipped.

// Append multiple values.
ob.append(vector!['f', 'g']);
// We get a single `VectorDiff`.
assert_next_eq!(sub, VectorDiff::Append { values: vector!['f', 'g'] });

// Let's recap what we have:
// | `ob`  | a b c d e f g |
// | `sub` | _ _ _ d e f g |
//                     ^^^
//                     |
//                     `VectorDiff::Append { .. }`

// Insert a single value.
ob.insert(1, 'h');
// We get a single `VectorDiff::PushFront`. Indeed, `h` is inserted at
// index 1, so every value after that is shifted to the right, thus `c`
// “enters the view” via a `PushFront`.
assert_next_eq!(sub, VectorDiff::PushFront { value: 'c' });

// Let's recap what we have:
// | `ob`  | a h b c d e f g |
// | `sub` | _ _ _ c d e f g |
//                 ^
//                 |
//                 `VectorDiff::PushFront { .. }`

assert_pending!(sub);
drop(ob);
assert_closed!(sub);
```


---

* Built on top of #69.