### PR TITLE
chore: Update `typos`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,4 +79,4 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.16.22
+      - uses: crate-ci/typos@v1.29.4

--- a/eyeball/src/shared.rs
+++ b/eyeball/src/shared.rs
@@ -1,4 +1,4 @@
-//! This module defines a [`SharedObservable`] type that is clonable, requires
+//! This module defines a [`SharedObservable`] type that is cloneable, requires
 //! only `&` access to update its inner value but doesn't dereference to the
 //! inner value.
 //!


### PR DESCRIPTION
This patch updates `crates-ci/typos` from 1.16.22 to 1.29.4.

This patch also fixes an existing typo in the code base.