### PR TITLE
Remove 'skeep' Vector extension method

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,2 +1,0 @@
-[default.extend-words]
-skeep = "skeep"


### PR DESCRIPTION
Its only purpose was to be more efficient than Vector::skip, which it no longer is.